### PR TITLE
Set offline partitions as true if leader is null

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -18,6 +18,8 @@ import java.util.stream.Stream;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.config.TopicConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @JsonResponseClass
@@ -35,6 +37,7 @@ public class ClusterPartitionState {
   public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
   public static final int DEFAULT_MIN_INSYNC_REPLICAS = 1;
   public static final boolean DEFAULT_REMOTE_STORAGE_ENABLED = false;
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterPartitionState.class);
 
   protected final Set<PartitionInfo> _underReplicatedPartitions;
   protected final Set<PartitionInfo> _offlinePartitions;
@@ -129,6 +132,7 @@ public class ClusterPartitionState {
           } else if (verbose) {
             otherPartitions.add(partitionInfo);
           }
+          LOG.warn("PI: {} -- LEADER: {}", partitionInfo, partitionInfo.leader());
         }
       }
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionStateTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionStateTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.response;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterPartitionStateTest {
+  private static final String TOPIC = "sample-topic";
+  private static final int PARTITION = 0;
+  private static final boolean VERBOSE = true;
+  private static final Pattern TOPIC_PATTERN = null;
+  private static final Map<String, Properties> ALL_TOPIC_CONFIGS = new HashMap<>();
+  private static final Properties CLUSTER_CONFIGS = new Properties();
+  private static final Node[] OFFLINE_REPLICAS = { };
+
+  @Test
+  public void testPopulateKafkaPartitionStateWithNoOfflinePartitions() {
+    Node leader = new Node(0, "localhost", 9092);
+    Node[] replicas = new Node[] { leader, new Node(1, "localhost", 9092)};
+    Node[] inSyncReplicas = { replicas[0], replicas[1] };
+
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, PARTITION, leader, replicas, inSyncReplicas, OFFLINE_REPLICAS);
+
+    Cluster kafkaCluster = new Cluster(
+      "clusterId", Arrays.asList(replicas), Arrays.asList(partitionInfo), Collections.emptySet(), Collections.emptySet()
+      );
+
+    ClusterPartitionState clusterPartitionState = new ClusterPartitionState(VERBOSE, TOPIC_PATTERN, kafkaCluster, ALL_TOPIC_CONFIGS, CLUSTER_CONFIGS);
+
+    assertTrue(clusterPartitionState._offlinePartitions.isEmpty());
+  }
+
+  @Test
+  public void testPopulateKafkaPartitionStateWithOfflinePartitions() {
+    Node leader = null;
+    Node[] replicas = { };
+    Node[] inSyncReplicas = { };
+
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, PARTITION, leader, replicas, inSyncReplicas, OFFLINE_REPLICAS);
+
+    Cluster kafkaCluster = new Cluster(
+      "clusterId", Arrays.asList(replicas), Arrays.asList(partitionInfo), Collections.emptySet(), Collections.emptySet()
+      );
+
+    Comparator<PartitionInfo> comparator = Comparator.comparing(PartitionInfo::topic).thenComparingInt(PartitionInfo::partition);
+    Set<PartitionInfo> offlinePartitions = new TreeSet<>(comparator);
+    offlinePartitions.add(partitionInfo);
+
+    ClusterPartitionState clusterPartitionState = new ClusterPartitionState(VERBOSE, TOPIC_PATTERN, kafkaCluster, ALL_TOPIC_CONFIGS, CLUSTER_CONFIGS);
+    assertEquals(offlinePartitions, clusterPartitionState._offlinePartitions);
+  }
+}


### PR DESCRIPTION
## What does this PR accomplish?
Currently, cruise-control detects offline partitions if the number of in-sync replicas is zero, and only performs this check if the partition is under-replicated. This definition of offline partitions is not comprehensive nor completely correct.

This PR corrects the detection of offline partitions by using the **status of a partition's leader** to determine whether a partition is offline. It also cleans up the conditional logic that determines whether a partition's status is checked to begin with.

**CURRENT STATE: cruise-control with an offline partition:**
<img width="1107" alt="Screenshot 2023-04-14 at 1 55 29 PM" src="https://user-images.githubusercontent.com/41079854/232121096-8edeb936-c05d-4bda-8ffe-e1439ffb0f1a.png">

**WITH THIS PR'S CHANGES: cruise-control with an offline partition:**
<img width="606" alt="Screenshot 2023-04-14 at 12 07 47 PM" src="https://user-images.githubusercontent.com/41079854/232097912-34c7316a-bbd7-43f7-a4ec-b5f575213af5.png">

## How was it tested?
1. Removed brokers in sandbox to create offline partitions. Confirmed that offline partitions are listed on the cruise-control UI (screenshot above).
2. Added a test for updated functionality
3. [to be done] Run in Shopify's production environment for a few days