### PR TITLE
Add check to protect against unclean leader elections related to `KAFKA-19148`

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -462,12 +462,14 @@ public class GoalOptimizer implements Runnable {
       OptimizationForGoal step = new OptimizationForGoal(goal.name());
       operationProgress.addStep(step);
       LOG.debug("Optimizing goal {}", goal.name());
-      
+
       // Automatically set Kafka cluster metadata for KAFKA-19148 protection
       if (goal instanceof AbstractGoal) {
-        ((AbstractGoal) goal).setKafkaCluster(_loadMonitor.kafkaCluster());
+        // Refresh metadata to ensure we have the latest cluster state
+        Cluster freshCluster = _loadMonitor.refreshClusterAndGeneration().cluster();
+        ((AbstractGoal) goal).setKafkaCluster(freshCluster);
       }
-      
+
       long startTimeMs = _time.milliseconds();
       boolean succeeded;
       try {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.common.Utils;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.AbstractGoal;
 import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
@@ -461,6 +462,12 @@ public class GoalOptimizer implements Runnable {
       OptimizationForGoal step = new OptimizationForGoal(goal.name());
       operationProgress.addStep(step);
       LOG.debug("Optimizing goal {}", goal.name());
+      
+      // Automatically set Kafka cluster metadata for KAFKA-19148 protection
+      if (goal instanceof AbstractGoal) {
+        ((AbstractGoal) goal).setKafkaCluster(_loadMonitor.kafkaCluster());
+      }
+      
       long startTimeMs = _time.milliseconds();
       boolean succeeded;
       try {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -149,8 +149,17 @@ public abstract class AbstractGoal implements Goal {
         return true;
       }
 
-      // We're moving the current leader - determine the new replica set after the move
-      // Use the current replica set from Kafka metadata, not the cluster model
+      // Special case: Single-replica partitions
+      if (currentReplicaIds.size() == 1) {
+        // Moving a single-replica partition means removing the current leader with no other replicas
+        // This is exactly the KAFKA-19148 scenario we need to prevent
+        LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} " +
+                 "with no other replicas. Should first add replica to destination broker {}",
+                 topicPartition, currentLeader.id(), destinationBroker.id());
+        return false;
+      }
+
+      // Multi-replica case: determine the new replica set after the move
       Set<Integer> newReplicaIds = new HashSet<>(currentReplicaIds);
       // Remove the source broker
       newReplicaIds.remove(replica.broker().id());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -186,8 +186,8 @@ public abstract class AbstractGoal implements Goal {
               .filter(id -> !currentIsrIds.contains(id))
               .collect(Collectors.toSet());
 
-          String blockKey = String.format("LEADER_REMOVAL_NON_ISR:%s:%d:non-isr%s",
-                                          topicPartition, currentLeader.id(), nonIsrReplicas);
+          String blockKey = String.format("LEADER_REMOVAL_NON_ISR:%s:%d:isr%s",
+                                          topicPartition, currentLeader.id(), currentIsrIds);
           if (_loggedKafka19148Blocks.add(blockKey)) {
             LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} "
                      + "while non-ISR replicas {} would remain in replica set. Current ISR: {}",

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -123,7 +123,7 @@ public abstract class AbstractGoal implements Goal {
       // Get current state from Kafka metadata
       Node currentLeader = partitionInfo.leader();
       if (currentLeader == null) {
-        LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing move", topicPartition);
+        LOG.debug("KAFKA-19148 check: Partition {} has no leader, allowing move", topicPartition);
         return true;
       }
 
@@ -137,15 +137,15 @@ public abstract class AbstractGoal implements Goal {
           .collect(Collectors.toSet());
 
       // Log current state for debugging
-      LOG.info("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, " +
-               "moving replica from broker {} to broker {}",
-               topicPartition, currentLeader.id(), currentReplicaIds, currentIsrIds,
-               replica.broker().id(), destinationBroker.id());
+      LOG.debug("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, " +
+                "moving replica from broker {} to broker {}",
+                topicPartition, currentLeader.id(), currentReplicaIds, currentIsrIds,
+                replica.broker().id(), destinationBroker.id());
 
       // Check if we're moving the current leader
       boolean movingCurrentLeader = currentLeader.id() == replica.broker().id();
       if (!movingCurrentLeader) {
-        LOG.info("KAFKA-19148 check: Not moving current leader for {}, move is safe", topicPartition);
+        LOG.debug("KAFKA-19148 check: Not moving current leader for {}, move is safe", topicPartition);
         return true;
       }
 
@@ -185,8 +185,8 @@ public abstract class AbstractGoal implements Goal {
           return false;
         }
 
-        LOG.info("KAFKA-19148 check: Leader removal for {} is safe - all remaining replicas {} are in ISR {}",
-                 topicPartition, newReplicaIds, currentIsrIds);
+        LOG.debug("KAFKA-19148 check: Leader removal for {} is safe - all remaining replicas {} are in ISR {}",
+                  topicPartition, newReplicaIds, currentIsrIds);
       } else {
         // Moving leader within the replica set - check if destination is in ISR
         if (!currentIsrIds.contains(destinationBroker.id())) {
@@ -196,8 +196,8 @@ public abstract class AbstractGoal implements Goal {
           return false;
         }
 
-        LOG.info("KAFKA-19148 check: Leader movement for {} is safe - destination {} is in ISR",
-                 topicPartition, destinationBroker.id());
+        LOG.debug("KAFKA-19148 check: Leader movement for {} is safe - destination {} is in ISR",
+                  topicPartition, destinationBroker.id());
       }
 
     } catch (Exception e) {
@@ -404,8 +404,8 @@ public abstract class AbstractGoal implements Goal {
       if (acceptance == ACCEPT) {
         // Log when we're applying the move
         if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT || action == ActionType.INTER_BROKER_REPLICA_SWAP || action == ActionType.LEADERSHIP_MOVEMENT) {
-          LOG.info("Applying {} for partition {}: moving replica from broker {} to broker {}",
-                   action, replica.topicPartition(), replica.broker().id(), broker.id());
+          LOG.debug("Applying {} for partition {}: moving replica from broker {} to broker {}",
+                    action, replica.topicPartition(), replica.broker().id(), broker.id());
         }
         if (action == ActionType.LEADERSHIP_MOVEMENT) {
           clusterModel.relocateLeadership(replica.topicPartition(), replica.broker().id(), broker.id());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -22,6 +22,7 @@ import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.model.Partition;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.HashSet;
 
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.BROKER_REJECT;
@@ -92,24 +94,20 @@ public abstract class AbstractGoal implements Goal {
 
   /**
    * Safety check for KAFKA-19148: Prevent replica movements that could trigger unclean leader elections
-   * in KRaft mode. The issue occurs specifically when moving a leader replica to a broker that is not
-   * currently part of the partition's replica set (i.e., adding a new replica that is out-of-sync by definition).
+   * in KRaft mode. The issue occurs when removing the current leader from the replica set while
+   * there are non-ISR replicas in the remaining set.
    *
+   * @param clusterModel The cluster model.
    * @param replica The replica being moved.
    * @param destinationBroker The destination broker for the move.
    * @param action The type of action being performed.
    * @return true if the move is safe to proceed, false if it should be skipped.
    */
-  private boolean isReplicaMoveSafeForKRaft(Replica replica, Broker destinationBroker, ActionType action) {
-    // Only check inter-broker movements that could affect ISR (and if cluster metadata is available)
+  private boolean isReplicaMoveSafeForKRaft(ClusterModel clusterModel, Replica replica, Broker destinationBroker, ActionType action) {
+    // Only check inter-broker movements that could affect ISR
     if (_kafkaCluster == null ||
         (action != ActionType.INTER_BROKER_REPLICA_MOVEMENT &&
          action != ActionType.INTER_BROKER_REPLICA_SWAP)) {
-      return true;
-    }
-
-    // Only check if we're moving a leader replica
-    if (!replica.isLeader()) {
       return true;
     }
 
@@ -118,11 +116,17 @@ public abstract class AbstractGoal implements Goal {
     try {
       PartitionInfo partitionInfo = _kafkaCluster.partition(topicPartition);
       if (partitionInfo == null) {
-        LOG.warn("Partition {} does not exist, skipping safety check", topicPartition);
+        LOG.warn("KAFKA-19148 check: Partition {} does not exist in Kafka metadata, skipping move", topicPartition);
         return false;
       }
 
-      // Log current state for debugging
+      // Get current state from Kafka metadata
+      Node currentLeader = partitionInfo.leader();
+      if (currentLeader == null) {
+        LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing move", topicPartition);
+        return true;
+      }
+
       Set<Integer> currentReplicaIds = Arrays.stream(partitionInfo.replicas())
           .mapToInt(Node::id)
           .boxed()
@@ -132,93 +136,63 @@ public abstract class AbstractGoal implements Goal {
           .boxed()
           .collect(Collectors.toSet());
 
-      LOG.info("KAFKA-19148 check for {}: current replicas={}, ISR={}, leader={}, destination={}",
-               topicPartition, currentReplicaIds, currentIsrIds,
-               partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
-               destinationBroker.id());
+      // Log current state for debugging
+      LOG.info("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, " +
+               "moving replica from broker {} to broker {}",
+               topicPartition, currentLeader.id(), currentReplicaIds, currentIsrIds,
+               replica.broker().id(), destinationBroker.id());
 
-      // Check for replica set mismatch between cluster model and actual cluster
-      Set<Integer> modelReplicaIds = replica.partition().replicas().stream()
-          .mapToInt(r -> r.broker().id())
-          .boxed()
-          .collect(Collectors.toSet());
-
-      if (!modelReplicaIds.equals(currentReplicaIds)) {
-        LOG.warn("KAFKA-19148 check: Replica set mismatch for {} - model: {}, actual: {}. " +
-                 "Skipping move to avoid potential issues.",
-                 topicPartition, modelReplicaIds, currentReplicaIds);
-        return false;
+      // Check if we're moving the current leader
+      boolean movingCurrentLeader = currentLeader.id() == replica.broker().id();
+      if (!movingCurrentLeader) {
+        LOG.info("KAFKA-19148 check: Not moving current leader for {}, move is safe", topicPartition);
+        return true;
       }
 
-      // Check if destination broker is already part of the partition's replica set
-      boolean destinationIsExistingReplica = Arrays.stream(partitionInfo.replicas())
-          .anyMatch(node -> node.id() == destinationBroker.id());
+      // We're moving the current leader - determine the new replica set after the move
+      // Use the current replica set from Kafka metadata, not the cluster model
+      Set<Integer> newReplicaIds = new HashSet<>(currentReplicaIds);
+      // Remove the source broker
+      newReplicaIds.remove(replica.broker().id());
+      // Add the destination broker
+      newReplicaIds.add(destinationBroker.id());
 
-      // Check if we're moving the actual current leader
-      boolean replicaIsCurrentLeader = partitionInfo.leader() != null &&
-                                      partitionInfo.leader().id() == replica.broker().id();
+      // Check if the current leader will be removed from the replica set
+      boolean leaderBeingRemoved = !newReplicaIds.contains(currentLeader.id());
 
-      if (replicaIsCurrentLeader) {
-        // Moving the current leader - need additional checks
+      if (leaderBeingRemoved) {
+        // Critical check: When removing the current leader, ALL remaining replicas must be in ISR
+        // to prevent KRaft from electing an out-of-sync replica
+        boolean allNewReplicasInIsr = newReplicaIds.stream().allMatch(currentIsrIds::contains);
 
-        // Check if destination is in ISR
-        boolean destinationInIsr = Arrays.stream(partitionInfo.inSyncReplicas())
-            .anyMatch(node -> node.id() == destinationBroker.id());
+        if (!allNewReplicasInIsr) {
+          Set<Integer> nonIsrReplicas = newReplicaIds.stream()
+              .filter(id -> !currentIsrIds.contains(id))
+              .collect(Collectors.toSet());
 
-        if (!destinationInIsr) {
-          // Dangerous case: moving leader to a broker not in ISR
-          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
-                   "moving current leader from broker {} to destination broker {} which is not in ISR (ISR: {})",
-                   topicPartition, replica.broker().id(), destinationBroker.id(), currentIsrIds);
+          LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} " +
+                   "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
+                   topicPartition, currentLeader.id(), nonIsrReplicas, currentIsrIds);
           return false;
         }
 
-        // Also check if we're removing the leader from the replica set
-        // This happens when the cluster model shows a replica set change
-        Set<Integer> newReplicaIds = replica.partition().replicas().stream()
-            .filter(r -> r != replica) // Exclude the replica being moved
-            .mapToInt(r -> r.broker().id())
-            .boxed()
-            .collect(Collectors.toSet());
-        newReplicaIds.add(destinationBroker.id()); // Add the destination
-
-        LOG.info("KAFKA-19148 check for {} leader movement: current replicas={}, new replicas after move={}, " +
-                 "moving {} -> {}, leader being removed={}",
-                 topicPartition, currentReplicaIds, newReplicaIds,
-                 replica.broker().id(), destinationBroker.id(),
-                 !newReplicaIds.contains(replica.broker().id()));
-
-        if (!newReplicaIds.contains(replica.broker().id())) {
-          // We're removing the current leader from the replica set
-          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
-                   "this move would remove the current leader (broker {}) from the replica set",
-                   topicPartition, replica.broker().id());
+        LOG.info("KAFKA-19148 check: Leader removal for {} is safe - all remaining replicas {} are in ISR {}",
+                 topicPartition, newReplicaIds, currentIsrIds);
+      } else {
+        // Moving leader within the replica set - check if destination is in ISR
+        if (!currentIsrIds.contains(destinationBroker.id())) {
+          LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to " +
+                   "out-of-sync broker {}. Current ISR: {}",
+                   topicPartition, currentLeader.id(), destinationBroker.id(), currentIsrIds);
           return false;
         }
-      }
 
-      // KAFKA-19148 trigger condition: Moving leader to a new broker (not in replica set)
-      // This means we're adding a new replica (always out-of-sync) while removing the leader
-      if (!destinationIsExistingReplica) {
-        // Destination is not in current replica set - need to check if we're moving the actual leader
-        if (replicaIsCurrentLeader) {
-          // This is the dangerous case: moving the actual leader to a broker not in replica set
-          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
-                   "moving current leader from broker {} to destination broker {} which is not in current replica set",
-                   topicPartition, replica.broker().id(), destinationBroker.id());
-          return false;
-        } else if (replica.isLeader()) {
-          // Cluster model thinks it's a leader, but it's not the actual leader - safe to move
-          LOG.info("KAFKA-19148 check: Replica {} is marked as leader in cluster model but broker {} is not " +
-                   "the current leader (actual leader: {}). Safe to move to broker {}.",
-                   replica.topicPartition(), replica.broker().id(),
-                   partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
-                   destinationBroker.id());
-        }
+        LOG.info("KAFKA-19148 check: Leader movement for {} is safe - destination {} is in ISR",
+                 topicPartition, destinationBroker.id());
       }
 
     } catch (Exception e) {
-      LOG.warn("Error during KAFKA-19148 safety check for partition {}, skipping move", topicPartition, e);
+      LOG.warn("KAFKA-19148 check: Error checking partition {}, skipping move for safety", topicPartition, e);
       return false;
     }
 
@@ -405,7 +379,7 @@ public abstract class AbstractGoal implements Goal {
       }
 
       // KAFKA-19148 safety check: Prevent replica movements that could trigger unclean leader elections
-      if (!isReplicaMoveSafeForKRaft(replica, broker, action)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, replica, broker, action)) {
         LOG.trace("Skipping replica move for {} to prevent KAFKA-19148.", proposal);
         continue;
       }
@@ -424,7 +398,11 @@ public abstract class AbstractGoal implements Goal {
           LOG.info("Applying {} for partition {}: moving replica from broker {} to broker {}",
                    action, replica.topicPartition(), replica.broker().id(), broker.id());
         }
-        clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
+        if (action == ActionType.LEADERSHIP_MOVEMENT) {
+          clusterModel.relocateLeadership(replica.topicPartition(), replica.broker().id(), broker.id());
+        } else if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT) {
+          clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
+        }
         return broker;
       } else if (acceptance == BROKER_REJECT) {
         LOG.trace("Broker rejected for {}: {}", replica.topicPartition(), proposal);
@@ -478,12 +456,12 @@ public abstract class AbstractGoal implements Goal {
       }
 
       // KAFKA-19148 safety check for both replicas involved in the swap
-      if (!isReplicaMoveSafeForKRaft(sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_SWAP)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_SWAP)) {
         LOG.trace("Skipping swap to prevent KAFKA-19148 for source replica in {}.", swapProposal);
         continue;
       }
 
-      if (!isReplicaMoveSafeForKRaft(destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_SWAP)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_SWAP)) {
         LOG.trace("Skipping swap to prevent KAFKA-19148 for destination replica in {}.", swapProposal);
         continue;
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -60,6 +60,8 @@ public abstract class AbstractGoal implements Goal {
   protected double _minMonitoredPartitionPercentage;
   protected ProvisionResponse _provisionResponse;
   protected Cluster _kafkaCluster;
+  // Track which KAFKA-19148 blocks have been logged to avoid spammy logs
+  private final Set<String> _loggedKafka19148Blocks = new HashSet<>();
 
   /**
    * Constructor of Abstract Goal class sets the
@@ -90,6 +92,8 @@ public abstract class AbstractGoal implements Goal {
    */
   public void setKafkaCluster(Cluster kafkaCluster) {
     _kafkaCluster = kafkaCluster;
+    // Clear logged blocks when cluster metadata is refreshed for a new optimization run
+    _loggedKafka19148Blocks.clear();
   }
 
   /**
@@ -116,7 +120,10 @@ public abstract class AbstractGoal implements Goal {
     try {
       PartitionInfo partitionInfo = _kafkaCluster.partition(topicPartition);
       if (partitionInfo == null) {
-        LOG.warn("KAFKA-19148 check: Partition {} does not exist in Kafka metadata, skipping move", topicPartition);
+        String blockKey = String.format("NO_METADATA:%s", topicPartition);
+        if (_loggedKafka19148Blocks.add(blockKey)) {
+          LOG.warn("KAFKA-19148 check: Partition {} does not exist in Kafka metadata, skipping move", topicPartition);
+        }
         return false;
       }
 
@@ -153,9 +160,12 @@ public abstract class AbstractGoal implements Goal {
       if (currentReplicaIds.size() == 1) {
         // Moving a single-replica partition means removing the current leader with no other replicas
         // This is exactly the KAFKA-19148 scenario we need to prevent
-        LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} " +
-                 "with no other replicas. Should first add replica to destination broker {}",
-                 topicPartition, currentLeader.id(), destinationBroker.id());
+        String blockKey = String.format("SINGLE_REPLICA:%s:%d->%d", topicPartition, currentLeader.id(), destinationBroker.id());
+        if (_loggedKafka19148Blocks.add(blockKey)) {
+          LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} " +
+                   "with no other replicas. Should first add replica to destination broker {}",
+                   topicPartition, currentLeader.id(), destinationBroker.id());
+        }
         return false;
       }
 
@@ -179,9 +189,13 @@ public abstract class AbstractGoal implements Goal {
               .filter(id -> !currentIsrIds.contains(id))
               .collect(Collectors.toSet());
 
-          LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} " +
-                   "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
-                   topicPartition, currentLeader.id(), nonIsrReplicas, currentIsrIds);
+          String blockKey = String.format("LEADER_REMOVAL_NON_ISR:%s:%d:non-isr%s",
+                                          topicPartition, currentLeader.id(), nonIsrReplicas);
+          if (_loggedKafka19148Blocks.add(blockKey)) {
+            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} " +
+                     "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
+                     topicPartition, currentLeader.id(), nonIsrReplicas, currentIsrIds);
+          }
           return false;
         }
 
@@ -190,9 +204,13 @@ public abstract class AbstractGoal implements Goal {
       } else {
         // Moving leader within the replica set - check if destination is in ISR
         if (!currentIsrIds.contains(destinationBroker.id())) {
-          LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to " +
-                   "out-of-sync broker {}. Current ISR: {}",
-                   topicPartition, currentLeader.id(), destinationBroker.id(), currentIsrIds);
+          String blockKey = String.format("LEADER_TO_NON_ISR:%s:%d->%d",
+                                          topicPartition, currentLeader.id(), destinationBroker.id());
+          if (_loggedKafka19148Blocks.add(blockKey)) {
+            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to " +
+                     "out-of-sync broker {}. Current ISR: {}",
+                     topicPartition, currentLeader.id(), destinationBroker.id(), currentIsrIds);
+          }
           return false;
         }
 
@@ -240,6 +258,11 @@ public abstract class AbstractGoal implements Goal {
       LOG.trace("[POST - {}] {}", name(), statsAfterOptimization);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Finished optimization for {} in {}ms.", name(), System.currentTimeMillis() - goalStartTime);
+      }
+      // Log KAFKA-19148 block summary if any movements were blocked
+      if (!_loggedKafka19148Blocks.isEmpty()) {
+        LOG.info("KAFKA-19148 summary for goal {}: {} unique movements were blocked to prevent unclean leader elections",
+                 name(), _loggedKafka19148Blocks.size());
       }
       LOG.trace("Cluster after optimization is {}", clusterModel);
       // The optimization cannot make stats worse unless the cluster has (1) broken brokers or (2) excluded brokers for replica move with replicas.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -16,13 +16,10 @@ import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionStatus;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
-import com.linkedin.kafka.cruisecontrol.exception.PartitionNotExistsException;
-import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Disk;
-import com.linkedin.kafka.cruisecontrol.model.Partition;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import java.util.Arrays;
 import java.util.List;
@@ -109,9 +106,9 @@ public abstract class AbstractGoal implements Goal {
    */
   private boolean isReplicaMoveSafeForKRaft(ClusterModel clusterModel, Replica replica, Broker destinationBroker, ActionType action) {
     // Only check inter-broker movements that could affect ISR
-    if (_kafkaCluster == null ||
-        (action != ActionType.INTER_BROKER_REPLICA_MOVEMENT &&
-         action != ActionType.INTER_BROKER_REPLICA_SWAP)) {
+    if (_kafkaCluster == null
+        || (action != ActionType.INTER_BROKER_REPLICA_MOVEMENT
+            && action != ActionType.INTER_BROKER_REPLICA_SWAP)) {
       return true;
     }
 
@@ -144,8 +141,8 @@ public abstract class AbstractGoal implements Goal {
           .collect(Collectors.toSet());
 
       // Log current state for debugging
-      LOG.debug("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, " +
-                "moving replica from broker {} to broker {}",
+      LOG.debug("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, "
+                + "moving replica from broker {} to broker {}",
                 topicPartition, currentLeader.id(), currentReplicaIds, currentIsrIds,
                 replica.broker().id(), destinationBroker.id());
 
@@ -162,8 +159,8 @@ public abstract class AbstractGoal implements Goal {
         // This is exactly the KAFKA-19148 scenario we need to prevent
         String blockKey = String.format("SINGLE_REPLICA:%s:%d->%d", topicPartition, currentLeader.id(), destinationBroker.id());
         if (_loggedKafka19148Blocks.add(blockKey)) {
-          LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} " +
-                   "with no other replicas. Should first add replica to destination broker {}",
+          LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} "
+                   + "with no other replicas. Should first add replica to destination broker {}",
                    topicPartition, currentLeader.id(), destinationBroker.id());
         }
         return false;
@@ -192,8 +189,8 @@ public abstract class AbstractGoal implements Goal {
           String blockKey = String.format("LEADER_REMOVAL_NON_ISR:%s:%d:non-isr%s",
                                           topicPartition, currentLeader.id(), nonIsrReplicas);
           if (_loggedKafka19148Blocks.add(blockKey)) {
-            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} " +
-                     "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
+            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} "
+                     + "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
                      topicPartition, currentLeader.id(), nonIsrReplicas, currentIsrIds);
           }
           return false;
@@ -207,8 +204,8 @@ public abstract class AbstractGoal implements Goal {
           String blockKey = String.format("LEADER_TO_NON_ISR:%s:%d->%d",
                                           topicPartition, currentLeader.id(), destinationBroker.id());
           if (_loggedKafka19148Blocks.add(blockKey)) {
-            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to " +
-                     "out-of-sync broker {}. Current ISR: {}",
+            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to "
+                     + "out-of-sync broker {}. Current ISR: {}",
                      topicPartition, currentLeader.id(), destinationBroker.id(), currentIsrIds);
           }
           return false;
@@ -426,7 +423,9 @@ public abstract class AbstractGoal implements Goal {
                 proposal, replica.topicPartition(), acceptance);
       if (acceptance == ACCEPT) {
         // Log when we're applying the move
-        if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT || action == ActionType.INTER_BROKER_REPLICA_SWAP || action == ActionType.LEADERSHIP_MOVEMENT) {
+        if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT
+            || action == ActionType.INTER_BROKER_REPLICA_SWAP
+            || action == ActionType.LEADERSHIP_MOVEMENT) {
           LOG.debug("Applying {} for partition {}: moving replica from broker {} to broker {}",
                     action, replica.topicPartition(), replica.broker().id(), broker.id());
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -59,6 +59,8 @@ public abstract class AbstractGoal implements Goal {
   protected Cluster _kafkaCluster;
   // Track which KAFKA-19148 blocks have been logged to avoid spammy logs
   private final Set<String> _loggedKafka19148Blocks = new HashSet<>();
+  // Track blocked proposals that should be marked as DEAD
+  private final Set<BalancingAction> _kafka19148BlockedProposals = new HashSet<>();
 
   /**
    * Constructor of Abstract Goal class sets the
@@ -91,6 +93,17 @@ public abstract class AbstractGoal implements Goal {
     _kafkaCluster = kafkaCluster;
     // Clear logged blocks when cluster metadata is refreshed for a new optimization run
     _loggedKafka19148Blocks.clear();
+    _kafka19148BlockedProposals.clear();
+  }
+
+  /**
+   * Get the set of proposals that were blocked due to KAFKA-19148 safety checks.
+   * These proposals should be marked as DEAD to prevent infinite re-execution loops.
+   *
+   * @return The set of blocked proposals.
+   */
+  public Set<BalancingAction> getKafka19148BlockedProposals() {
+    return new HashSet<>(_kafka19148BlockedProposals);
   }
 
   /**
@@ -102,9 +115,14 @@ public abstract class AbstractGoal implements Goal {
    * @param replica The replica being moved.
    * @param destinationBroker The destination broker for the move.
    * @param action The type of action being performed.
+   * @param proposal The balancing proposal being checked (can be null).
    * @return true if the move is safe to proceed, false if it should be skipped.
    */
-  private boolean isReplicaMoveSafeForKRaft(ClusterModel clusterModel, Replica replica, Broker destinationBroker, ActionType action) {
+  private boolean isReplicaMoveSafeForKRaft(ClusterModel clusterModel,
+                                           Replica replica,
+                                           Broker destinationBroker,
+                                           ActionType action,
+                                           BalancingAction proposal) {
     // Only check inter-broker movements that could affect ISR
     if (_kafkaCluster == null
         || (action != ActionType.INTER_BROKER_REPLICA_MOVEMENT
@@ -119,7 +137,11 @@ public abstract class AbstractGoal implements Goal {
       if (partitionInfo == null) {
         String blockKey = String.format("NO_METADATA:%s", topicPartition);
         if (_loggedKafka19148Blocks.add(blockKey)) {
-          LOG.warn("KAFKA-19148 check: Partition {} does not exist in Kafka metadata, skipping move", topicPartition);
+          LOG.debug("KAFKA-19148 check: Partition {} does not exist in Kafka metadata, skipping move", topicPartition);
+        }
+        // Track this blocked proposal
+        if (proposal != null) {
+          _kafka19148BlockedProposals.add(proposal);
         }
         return false;
       }
@@ -140,6 +162,18 @@ public abstract class AbstractGoal implements Goal {
           .boxed()
           .collect(Collectors.toSet());
 
+      // Check if any current replicas are on dead brokers
+      boolean hasDeadReplicas = currentReplicaIds.stream()
+          .anyMatch(brokerId -> {
+            Broker broker = clusterModel.broker(brokerId);
+            return broker == null || !broker.isAlive();
+          });
+
+      if (hasDeadReplicas) {
+        LOG.debug("KAFKA-19148 check: Partition {} has dead replicas, allowing move for recovery", topicPartition);
+        return true;
+      }
+
       // Log current state for debugging
       LOG.debug("KAFKA-19148 check for {}: current leader={}, replicas={}, ISR={}, "
                 + "moving replica from broker {} to broker {}",
@@ -159,9 +193,13 @@ public abstract class AbstractGoal implements Goal {
         // This is exactly the KAFKA-19148 scenario we need to prevent
         String blockKey = String.format("SINGLE_REPLICA:%s:%d->%d", topicPartition, currentLeader.id(), destinationBroker.id());
         if (_loggedKafka19148Blocks.add(blockKey)) {
-          LOG.warn("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} "
+          LOG.debug("KAFKA-19148 BLOCKED: Cannot move single-replica partition {} - would remove current leader {} "
                    + "with no other replicas. Should first add replica to destination broker {}",
                    topicPartition, currentLeader.id(), destinationBroker.id());
+        }
+
+        if (proposal != null) {
+          _kafka19148BlockedProposals.add(proposal);
         }
         return false;
       }
@@ -189,9 +227,13 @@ public abstract class AbstractGoal implements Goal {
           String blockKey = String.format("LEADER_REMOVAL_NON_ISR:%s:%d:isr%s",
                                           topicPartition, currentLeader.id(), currentIsrIds);
           if (_loggedKafka19148Blocks.add(blockKey)) {
-            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} "
+            LOG.debug("KAFKA-19148 BLOCKED: Skipping movement for partition {} - removing current leader {} "
                      + "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
                      topicPartition, currentLeader.id(), nonIsrReplicas, currentIsrIds);
+          }
+          // Track this blocked proposal
+          if (proposal != null) {
+            _kafka19148BlockedProposals.add(proposal);
           }
           return false;
         }
@@ -204,9 +246,13 @@ public abstract class AbstractGoal implements Goal {
           String blockKey = String.format("LEADER_TO_NON_ISR:%s:%d->%d",
                                           topicPartition, currentLeader.id(), destinationBroker.id());
           if (_loggedKafka19148Blocks.add(blockKey)) {
-            LOG.warn("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to "
+            LOG.debug("KAFKA-19148 BLOCKED: Skipping movement for partition {} - moving leader {} to "
                      + "out-of-sync broker {}. Current ISR: {}",
                      topicPartition, currentLeader.id(), destinationBroker.id(), currentIsrIds);
+          }
+
+          if (proposal != null) {
+            _kafka19148BlockedProposals.add(proposal);
           }
           return false;
         }
@@ -408,7 +454,7 @@ public abstract class AbstractGoal implements Goal {
       }
 
       // KAFKA-19148 safety check: Prevent replica movements that could trigger unclean leader elections
-      if (!isReplicaMoveSafeForKRaft(clusterModel, replica, broker, action)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, replica, broker, action, proposal)) {
         LOG.trace("Skipping replica move for {} to prevent KAFKA-19148.", proposal);
         continue;
       }
@@ -487,12 +533,12 @@ public abstract class AbstractGoal implements Goal {
       }
 
       // KAFKA-19148 safety check for both replicas involved in the swap
-      if (!isReplicaMoveSafeForKRaft(clusterModel, sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_SWAP)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_SWAP, swapProposal)) {
         LOG.trace("Skipping swap to prevent KAFKA-19148 for source replica in {}.", swapProposal);
         continue;
       }
 
-      if (!isReplicaMoveSafeForKRaft(clusterModel, destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_SWAP)) {
+      if (!isReplicaMoveSafeForKRaft(clusterModel, destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_SWAP, swapProposal)) {
         LOG.trace("Skipping swap to prevent KAFKA-19148 for destination replica in {}.", swapProposal);
         continue;
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -16,14 +16,20 @@ import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionStatus;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.exception.PartitionNotExistsException;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Disk;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collection;
@@ -50,6 +56,7 @@ public abstract class AbstractGoal implements Goal {
   protected int _numWindows;
   protected double _minMonitoredPartitionPercentage;
   protected ProvisionResponse _provisionResponse;
+  protected Cluster _kafkaCluster;
 
   /**
    * Constructor of Abstract Goal class sets the
@@ -71,6 +78,68 @@ public abstract class AbstractGoal implements Goal {
     _balancingConstraint = new BalancingConstraint(parsedConfig);
     _numWindows = parsedConfig.getInt(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
     _minMonitoredPartitionPercentage = parsedConfig.getDouble(MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
+  }
+
+  /**
+   * Set the Kafka cluster metadata for ISR safety checks.
+   *
+   * @param kafkaCluster The Kafka cluster metadata.
+   */
+  public void setKafkaCluster(Cluster kafkaCluster) {
+    _kafkaCluster = kafkaCluster;
+  }
+
+  /**
+   * Safety check for KAFKA-19148: Prevent replica movements that could trigger unclean leader elections
+   * in KRaft mode. The issue occurs specifically when moving a leader replica to a broker that is not
+   * currently part of the partition's replica set (i.e., adding a new replica that is out-of-sync by definition).
+   *
+   * @param replica The replica being moved.
+   * @param destinationBroker The destination broker for the move.
+   * @param action The type of action being performed.
+   * @return true if the move is safe to proceed, false if it should be skipped.
+   */
+  private boolean isReplicaMoveSafeForKRaft(Replica replica, Broker destinationBroker, ActionType action) {
+    // Only check inter-broker movements that could affect ISR (and if cluster metadata is available)
+    if (_kafkaCluster == null ||
+        (action != ActionType.INTER_BROKER_REPLICA_MOVEMENT &&
+         action != ActionType.INTER_BROKER_REPLICA_SWAP)) {
+      return true;
+    }
+
+    // Only check if we're moving a leader replica
+    if (!replica.isLeader()) {
+      return true;
+    }
+
+    org.apache.kafka.common.TopicPartition topicPartition = replica.topicPartition();
+
+    try {
+      PartitionInfo partitionInfo = _kafkaCluster.partition(topicPartition);
+      if (partitionInfo == null) {
+        LOG.warn("Partition {} does not exist, skipping safety check", topicPartition);
+        return false;
+      }
+
+      // Check if destination broker is already part of the partition's replica set
+      boolean destinationIsExistingReplica = Arrays.stream(partitionInfo.replicas())
+          .anyMatch(node -> node.id() == destinationBroker.id());
+
+      // KAFKA-19148 trigger condition: Moving leader to a new broker (not in replica set)
+      // This means we're adding a new replica (always out-of-sync) while removing the leader
+      if (!destinationIsExistingReplica) {
+        LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
+                 "destination broker {} is not in current replica set, would add new out-of-sync replica while removing leader",
+                 topicPartition, destinationBroker.id());
+        return false;
+      }
+
+    } catch (Exception e) {
+      LOG.warn("Error during KAFKA-19148 safety check for partition {}, skipping move", topicPartition, e);
+      return false;
+    }
+
+    return true;
   }
 
   private static boolean hasExcludedBrokersForReplicaMoveWithReplicas(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
@@ -252,6 +321,12 @@ public abstract class AbstractGoal implements Goal {
         continue;
       }
 
+      // KAFKA-19148 safety check: Prevent replica movements that could trigger unclean leader elections
+      if (!isReplicaMoveSafeForKRaft(replica, broker, action)) {
+        LOG.trace("Skipping replica move to prevent KAFKA-19148 for {}.", proposal);
+        continue;
+      }
+
       if (!selfSatisfied(clusterModel, proposal)) {
         LOG.trace("Unable to self-satisfy proposal {}.", proposal);
         continue;
@@ -312,6 +387,17 @@ public abstract class AbstractGoal implements Goal {
 
       if (!legitMove(destinationReplica, sourceReplica.broker(), clusterModel, ActionType.INTER_BROKER_REPLICA_MOVEMENT)) {
         LOG.trace("Swap from destination to source broker is not legit for {}.", swapProposal);
+        continue;
+      }
+
+      // KAFKA-19148 safety check for both replicas involved in the swap
+      if (!isReplicaMoveSafeForKRaft(sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_SWAP)) {
+        LOG.trace("Skipping swap to prevent KAFKA-19148 for source replica in {}.", swapProposal);
+        continue;
+      }
+
+      if (!isReplicaMoveSafeForKRaft(destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_SWAP)) {
+        LOG.trace("Skipping swap to prevent KAFKA-19148 for destination replica in {}.", swapProposal);
         continue;
       }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.BROKER_REJECT;
@@ -121,17 +122,99 @@ public abstract class AbstractGoal implements Goal {
         return false;
       }
 
+      // Log current state for debugging
+      Set<Integer> currentReplicaIds = Arrays.stream(partitionInfo.replicas())
+          .mapToInt(Node::id)
+          .boxed()
+          .collect(Collectors.toSet());
+      Set<Integer> currentIsrIds = Arrays.stream(partitionInfo.inSyncReplicas())
+          .mapToInt(Node::id)
+          .boxed()
+          .collect(Collectors.toSet());
+
+      LOG.info("KAFKA-19148 check for {}: current replicas={}, ISR={}, leader={}, destination={}",
+               topicPartition, currentReplicaIds, currentIsrIds,
+               partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
+               destinationBroker.id());
+
+      // Check for replica set mismatch between cluster model and actual cluster
+      Set<Integer> modelReplicaIds = replica.partition().replicas().stream()
+          .mapToInt(r -> r.broker().id())
+          .boxed()
+          .collect(Collectors.toSet());
+
+      if (!modelReplicaIds.equals(currentReplicaIds)) {
+        LOG.warn("KAFKA-19148 check: Replica set mismatch for {} - model: {}, actual: {}. " +
+                 "Skipping move to avoid potential issues.",
+                 topicPartition, modelReplicaIds, currentReplicaIds);
+        return false;
+      }
+
       // Check if destination broker is already part of the partition's replica set
       boolean destinationIsExistingReplica = Arrays.stream(partitionInfo.replicas())
           .anyMatch(node -> node.id() == destinationBroker.id());
 
+      // Check if we're moving the actual current leader
+      boolean replicaIsCurrentLeader = partitionInfo.leader() != null &&
+                                      partitionInfo.leader().id() == replica.broker().id();
+
+      if (replicaIsCurrentLeader) {
+        // Moving the current leader - need additional checks
+
+        // Check if destination is in ISR
+        boolean destinationInIsr = Arrays.stream(partitionInfo.inSyncReplicas())
+            .anyMatch(node -> node.id() == destinationBroker.id());
+
+        if (!destinationInIsr) {
+          // Dangerous case: moving leader to a broker not in ISR
+          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
+                   "moving current leader from broker {} to destination broker {} which is not in ISR (ISR: {})",
+                   topicPartition, replica.broker().id(), destinationBroker.id(), currentIsrIds);
+          return false;
+        }
+
+        // Also check if we're removing the leader from the replica set
+        // This happens when the cluster model shows a replica set change
+        Set<Integer> newReplicaIds = replica.partition().replicas().stream()
+            .filter(r -> r != replica) // Exclude the replica being moved
+            .mapToInt(r -> r.broker().id())
+            .boxed()
+            .collect(Collectors.toSet());
+        newReplicaIds.add(destinationBroker.id()); // Add the destination
+
+        LOG.info("KAFKA-19148 check for {} leader movement: current replicas={}, new replicas after move={}, " +
+                 "moving {} -> {}, leader being removed={}",
+                 topicPartition, currentReplicaIds, newReplicaIds,
+                 replica.broker().id(), destinationBroker.id(),
+                 !newReplicaIds.contains(replica.broker().id()));
+
+        if (!newReplicaIds.contains(replica.broker().id())) {
+          // We're removing the current leader from the replica set
+          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
+                   "this move would remove the current leader (broker {}) from the replica set",
+                   topicPartition, replica.broker().id());
+          return false;
+        }
+      }
+
       // KAFKA-19148 trigger condition: Moving leader to a new broker (not in replica set)
       // This means we're adding a new replica (always out-of-sync) while removing the leader
       if (!destinationIsExistingReplica) {
-        LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
-                 "destination broker {} is not in current replica set, would add new out-of-sync replica while removing leader",
-                 topicPartition, destinationBroker.id());
-        return false;
+        // Destination is not in current replica set - need to check if we're moving the actual leader
+        if (replicaIsCurrentLeader) {
+          // This is the dangerous case: moving the actual leader to a broker not in replica set
+          LOG.warn("Skipping leader replica movement for partition {} to prevent KAFKA-19148: " +
+                   "moving current leader from broker {} to destination broker {} which is not in current replica set",
+                   topicPartition, replica.broker().id(), destinationBroker.id());
+          return false;
+        } else if (replica.isLeader()) {
+          // Cluster model thinks it's a leader, but it's not the actual leader - safe to move
+          LOG.info("KAFKA-19148 check: Replica {} is marked as leader in cluster model but broker {} is not " +
+                   "the current leader (actual leader: {}). Safe to move to broker {}.",
+                   replica.topicPartition(), replica.broker().id(),
+                   partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
+                   destinationBroker.id());
+        }
       }
 
     } catch (Exception e) {
@@ -323,7 +406,7 @@ public abstract class AbstractGoal implements Goal {
 
       // KAFKA-19148 safety check: Prevent replica movements that could trigger unclean leader elections
       if (!isReplicaMoveSafeForKRaft(replica, broker, action)) {
-        LOG.trace("Skipping replica move to prevent KAFKA-19148 for {}.", proposal);
+        LOG.trace("Skipping replica move for {} to prevent KAFKA-19148.", proposal);
         continue;
       }
 
@@ -333,14 +416,18 @@ public abstract class AbstractGoal implements Goal {
       }
 
       ActionAcceptance acceptance = AnalyzerUtils.isProposalAcceptableForOptimizedGoals(optimizedGoals, proposal, clusterModel);
-      LOG.trace("Trying to apply legit and self-satisfied action {}, actionAcceptance = {}", proposal, acceptance);
+      LOG.trace("Trying to apply legit and self-satisfied action {} for {}, actionAcceptance = {}",
+                proposal, replica.topicPartition(), acceptance);
       if (acceptance == ACCEPT) {
-        if (action == ActionType.LEADERSHIP_MOVEMENT) {
-          clusterModel.relocateLeadership(replica.topicPartition(), replica.broker().id(), broker.id());
-        } else if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT) {
-          clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
+        // Log when we're applying the move
+        if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT || action == ActionType.INTER_BROKER_REPLICA_SWAP || action == ActionType.LEADERSHIP_MOVEMENT) {
+          LOG.info("Applying {} for partition {}: moving replica from broker {} to broker {}",
+                   action, replica.topicPartition(), replica.broker().id(), broker.id());
         }
+        clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
         return broker;
+      } else if (acceptance == BROKER_REJECT) {
+        LOG.trace("Broker rejected for {}: {}", replica.topicPartition(), proposal);
       }
     }
     return null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
@@ -217,7 +217,8 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
     Set<Broker> candidateBrokers = Collections.singleton(broker);
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
     boolean fastMode = optimizationOptions.fastMode();
-    for (Replica replica : broker.replicas()) {
+    // Create a copy to avoid ConcurrentModificationException when the collection is modified during iteration
+    for (Replica replica : new HashSet<>(broker.replicas())) {
       if (fastMode && remainingTimeMs(_balancingConstraint.fastModePerBrokerMoveTimeoutMs(), moveStartTimeMs) <= 0) {
         LOG.debug("Move leadership in timeout in fast mode for broker {}.", broker.id());
         break;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -259,7 +259,8 @@ public class ExecutionTaskPlanner {
    */
   private void maybeAddLeaderChangeTasks(Collection<ExecutionProposal> proposals, Cluster cluster) {
     for (ExecutionProposal proposal : proposals) {
-      if (proposal.hasLeaderAction()) {
+      // Only create LEADER_ACTION tasks for pure leadership movements (no replica set changes)
+      if (proposal.hasLeaderAction() && !proposal.hasReplicaAction()) {
         Node currentLeader = cluster.leaderFor(proposal.topicPartition());
         if (currentLeader != null && currentLeader.id() != proposal.newLeader().brokerId()) {
           // Get the execution Id for the leader action proposal execution;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -227,16 +227,16 @@ public class ExecutionTaskPlanner {
         ExecutionTask executionTask = new ExecutionTask(replicaActionExecutionId, proposal, INTER_BROKER_REPLICA_ACTION,
                                                         executionAlertingThresholdMs);
         _remainingInterBrokerReplicaMovements.add(executionTask);
-        LOG.info("KAFKA-19148 TASK CREATION: Created INTER_BROKER_REPLICA_ACTION task {} for partition {} with proposal: {} -> {}, " +
-                 "oldLeader={}, newLeader={}, current cluster state - leader={}, ISR={}, replicas={}",
-                 replicaActionExecutionId, proposal.topicPartition(),
-                 proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
-                 proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
-                 proposal.oldLeader().brokerId(),
-                 proposal.newLeader().brokerId(),
-                 partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
-                 Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
-                 Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList()));
+        LOG.debug("KAFKA-19148 TASK CREATION: Created INTER_BROKER_REPLICA_ACTION task {} for partition {} with proposal: {} -> {}, " +
+                  "oldLeader={}, newLeader={}, current cluster state - leader={}, ISR={}, replicas={}",
+                  replicaActionExecutionId, proposal.topicPartition(),
+                  proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
+                  proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
+                  proposal.oldLeader().brokerId(),
+                  proposal.newLeader().brokerId(),
+                  partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
+                  Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
+                  Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList()));
         LOG.trace("Added action {} as replica proposal {}", replicaActionExecutionId, proposal);
       }
     }
@@ -264,8 +264,8 @@ public class ExecutionTaskPlanner {
   private boolean wouldCauseUncleanLeaderElection(ExecutionProposal proposal, PartitionInfo partitionInfo) {
     // Get current leader
     if (partitionInfo.leader() == null) {
-      LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing proposal",
-               proposal.topicPartition());
+      LOG.debug("KAFKA-19148 check: Partition {} has no leader, allowing proposal",
+                proposal.topicPartition());
       return false;
     }
     int currentLeader = partitionInfo.leader().id();
@@ -281,10 +281,10 @@ public class ExecutionTaskPlanner {
         .collect(Collectors.toSet());
 
     // Log the check details
-    LOG.info("KAFKA-19148 check for partition {}: current leader={}, current ISR={}, " +
-             "proposed replicas={}, old replicas={}",
-             proposal.topicPartition(), currentLeader, currentIsr, proposedReplicas,
-             proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()));
+    LOG.debug("KAFKA-19148 check for partition {}: current leader={}, current ISR={}, " +
+              "proposed replicas={}, old replicas={}",
+              proposal.topicPartition(), currentLeader, currentIsr, proposedReplicas,
+              proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()));
 
     // Check if current leader is being removed from replica set
     if (!proposedReplicas.contains(currentLeader)) {
@@ -303,9 +303,9 @@ public class ExecutionTaskPlanner {
         return true; // Would cause unclean election
       }
 
-      LOG.info("KAFKA-19148 check: Proposal for partition {} is safe - removing leader {} " +
-               "and all remaining replicas {} are in ISR",
-               proposal.topicPartition(), currentLeader, proposedReplicas);
+      LOG.debug("KAFKA-19148 check: Proposal for partition {} is safe - removing leader {} " +
+                "and all remaining replicas {} are in ISR",
+                proposal.topicPartition(), currentLeader, proposedReplicas);
     } else {
       // Leader not being removed - check if new leader would be in ISR
       if (proposal.newLeader().brokerId() != currentLeader &&
@@ -316,8 +316,8 @@ public class ExecutionTaskPlanner {
         return true; // Would cause unclean election
       }
 
-      LOG.info("KAFKA-19148 check: Proposal for partition {} is safe - leader remains or new leader is in ISR",
-               proposal.topicPartition());
+      LOG.debug("KAFKA-19148 check: Proposal for partition {} is safe - leader remains or new leader is in ISR",
+                proposal.topicPartition());
     }
 
     return false; // Safe to proceed
@@ -357,8 +357,8 @@ public class ExecutionTaskPlanner {
             ExecutionTask task = new ExecutionTask(replicaActionExecutionId, proposal, r.brokerId(), INTRA_BROKER_REPLICA_ACTION,
                                                    Math.max(Math.round(proposal.dataToMoveInMB() / _intraBrokerReplicaMovementRateAlertingThreshold),
                                                             _taskExecutionAlertingThresholdMs));
-            LOG.info("Created INTRA_BROKER_REPLICA_ACTION task {} for partition {} on broker {} moving from {} to {}",
-                     replicaActionExecutionId, proposal.topicPartition(), r.brokerId(), currentLogdir, r.logdir());
+            LOG.debug("Created INTRA_BROKER_REPLICA_ACTION task {} for partition {} on broker {} moving from {} to {}",
+                      replicaActionExecutionId, proposal.topicPartition(), r.brokerId(), currentLogdir, r.logdir());
             _intraPartMoveTasksByBrokerId.putIfAbsent(r.brokerId(), new TreeSet<>());
             _intraPartMoveTasksByBrokerId.get(r.brokerId()).add(task);
             _remainingIntraBrokerReplicaMovements.add(task);
@@ -384,12 +384,12 @@ public class ExecutionTaskPlanner {
           long leaderActionExecutionId = _executionId++;
           ExecutionTask leaderActionTask = new ExecutionTask(leaderActionExecutionId, proposal, LEADER_ACTION, _taskExecutionAlertingThresholdMs);
           _remainingLeadershipMovements.put(leaderActionExecutionId, leaderActionTask);
-          LOG.info("KAFKA-19148 TASK CREATION: Created LEADER_ACTION task {} for partition {} moving leadership from {} to {}, " +
-                   "current cluster state - leader={}, ISR={}, replicas={}",
-                   leaderActionExecutionId, proposal.topicPartition(), currentLeader.id(), proposal.newLeader().brokerId(),
-                   currentLeader.id(),
-                   Arrays.stream(cluster.partition(proposal.topicPartition()).inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
-                   Arrays.stream(cluster.partition(proposal.topicPartition()).replicas()).map(Node::id).collect(Collectors.toList()));
+          LOG.debug("KAFKA-19148 TASK CREATION: Created LEADER_ACTION task {} for partition {} moving leadership from {} to {}, " +
+                    "current cluster state - leader={}, ISR={}, replicas={}",
+                    leaderActionExecutionId, proposal.topicPartition(), currentLeader.id(), proposal.newLeader().brokerId(),
+                    currentLeader.id(),
+                    Arrays.stream(cluster.partition(proposal.topicPartition()).inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
+                    Arrays.stream(cluster.partition(proposal.topicPartition()).replicas()).map(Node::id).collect(Collectors.toList()));
           LOG.trace("Added action {} as leader proposal {}", leaderActionExecutionId, proposal);
         }
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -200,8 +200,8 @@ public class ExecutionTaskPlanner {
             .map(ReplicaPlacementInfo::brokerId)
             .collect(Collectors.toSet());
 
-        LOG.debug("Evaluating proposal for partition {}: current replicas={}, ISR={}, leader={}, " +
-                  "proposal: {} -> {}, oldLeader={}, newLeader={}",
+        LOG.debug("Evaluating proposal for partition {}: current replicas={}, ISR={}, leader={}, "
+                  + "proposal: {} -> {}, oldLeader={}, newLeader={}",
                   tp, currentReplicas, currentIsr,
                   partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
                   proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
@@ -212,8 +212,8 @@ public class ExecutionTaskPlanner {
 
       // KAFKA-19148 validation: Check if the proposal would cause unclean leader election
       if (wouldCauseUncleanLeaderElection(proposal, partitionInfo)) {
-        LOG.warn("Skipping proposal for partition {} to prevent KAFKA-19148: moving leader {} to broker {} " +
-                 "which would cause unclean election. Current replicas: {}, ISR: {}",
+        LOG.warn("Skipping proposal for partition {} to prevent KAFKA-19148: moving leader {} to broker {} "
+                 + "which would cause unclean election. Current replicas: {}, ISR: {}",
                  tp, proposal.oldLeader().brokerId(), proposal.newLeader().brokerId(),
                  Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList()),
                  Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList()));
@@ -227,8 +227,8 @@ public class ExecutionTaskPlanner {
         ExecutionTask executionTask = new ExecutionTask(replicaActionExecutionId, proposal, INTER_BROKER_REPLICA_ACTION,
                                                         executionAlertingThresholdMs);
         _remainingInterBrokerReplicaMovements.add(executionTask);
-        LOG.debug("KAFKA-19148 TASK CREATION: Created INTER_BROKER_REPLICA_ACTION task {} for partition {} with proposal: {} -> {}, " +
-                  "oldLeader={}, newLeader={}, current cluster state - leader={}, ISR={}, replicas={}",
+        LOG.debug("KAFKA-19148 TASK CREATION: Created INTER_BROKER_REPLICA_ACTION task {} for partition {} with proposal: {} -> {}, "
+                  + "oldLeader={}, newLeader={}, current cluster state - leader={}, ISR={}, replicas={}",
                   replicaActionExecutionId, proposal.topicPartition(),
                   proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
                   proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
@@ -281,8 +281,8 @@ public class ExecutionTaskPlanner {
         .collect(Collectors.toSet());
 
     // Log the check details
-    LOG.debug("KAFKA-19148 check for partition {}: current leader={}, current ISR={}, " +
-              "proposed replicas={}, old replicas={}",
+    LOG.debug("KAFKA-19148 check for partition {}: current leader={}, current ISR={}, "
+              + "proposed replicas={}, old replicas={}",
               proposal.topicPartition(), currentLeader, currentIsr, proposedReplicas,
               proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()));
 
@@ -297,30 +297,33 @@ public class ExecutionTaskPlanner {
             .filter(replica -> !currentIsr.contains(replica))
             .collect(Collectors.toSet());
 
-        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - removing current leader {} " +
-                 "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
+        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - removing current leader {} "
+                 + "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
                  proposal.topicPartition(), currentLeader, nonIsrReplicas, currentIsr);
-        return true; // Would cause unclean election
+        // Would cause unclean election
+        return true;
       }
 
-      LOG.debug("KAFKA-19148 check: Proposal for partition {} is safe - removing leader {} " +
-                "and all remaining replicas {} are in ISR",
+      LOG.debug("KAFKA-19148 check: Proposal for partition {} is safe - removing leader {} "
+                + "and all remaining replicas {} are in ISR",
                 proposal.topicPartition(), currentLeader, proposedReplicas);
     } else {
       // Leader not being removed - check if new leader would be in ISR
-      if (proposal.newLeader().brokerId() != currentLeader &&
-          !currentIsr.contains(proposal.newLeader().brokerId())) {
-        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - new leader {} is not in ISR. " +
-                 "Current leader: {}, current ISR: {}",
+      if (proposal.newLeader().brokerId() != currentLeader
+          && !currentIsr.contains(proposal.newLeader().brokerId())) {
+        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - new leader {} is not in ISR. "
+                 + "Current leader: {}, current ISR: {}",
                  proposal.topicPartition(), proposal.newLeader().brokerId(), currentLeader, currentIsr);
-        return true; // Would cause unclean election
+        // Would cause unclean election
+        return true;
       }
 
       LOG.debug("KAFKA-19148 check: Proposal for partition {} is safe - leader remains or new leader is in ISR",
                 proposal.topicPartition());
     }
 
-    return false; // Safe to proceed
+    // Safe to proceed
+    return false;
   }
 
   /**
@@ -384,8 +387,8 @@ public class ExecutionTaskPlanner {
           long leaderActionExecutionId = _executionId++;
           ExecutionTask leaderActionTask = new ExecutionTask(leaderActionExecutionId, proposal, LEADER_ACTION, _taskExecutionAlertingThresholdMs);
           _remainingLeadershipMovements.put(leaderActionExecutionId, leaderActionTask);
-          LOG.debug("KAFKA-19148 TASK CREATION: Created LEADER_ACTION task {} for partition {} moving leadership from {} to {}, " +
-                    "current cluster state - leader={}, ISR={}, replicas={}",
+          LOG.debug("KAFKA-19148 TASK CREATION: Created LEADER_ACTION task {} for partition {} moving leadership from {} to {}, "
+                    + "current cluster state - leader={}, ISR={}, replicas={}",
                     leaderActionExecutionId, proposal.topicPartition(), currentLeader.id(), proposal.newLeader().brokerId(),
                     currentLeader.id(),
                     Arrays.stream(cluster.partition(proposal.topicPartition()).inSyncReplicas()).map(Node::id).collect(Collectors.toList()),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -297,7 +297,7 @@ public class ExecutionTaskPlanner {
             .filter(replica -> !currentIsr.contains(replica))
             .collect(Collectors.toSet());
 
-        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - removing current leader {} "
+        LOG.debug("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - removing current leader {} "
                  + "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
                  proposal.topicPartition(), currentLeader, nonIsrReplicas, currentIsr);
         // Would cause unclean election
@@ -311,7 +311,7 @@ public class ExecutionTaskPlanner {
       // Leader not being removed - check if new leader would be in ISR
       if (proposal.newLeader().brokerId() != currentLeader
           && !currentIsr.contains(proposal.newLeader().brokerId())) {
-        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - new leader {} is not in ISR. "
+        LOG.debug("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - new leader {} is not in ISR. "
                  + "Current leader: {}, current ISR: {}",
                  proposal.topicPartition(), proposal.newLeader().brokerId(), currentLeader, currentIsr);
         // Would cause unclean election

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -227,6 +227,16 @@ public class ExecutionTaskPlanner {
         ExecutionTask executionTask = new ExecutionTask(replicaActionExecutionId, proposal, INTER_BROKER_REPLICA_ACTION,
                                                         executionAlertingThresholdMs);
         _remainingInterBrokerReplicaMovements.add(executionTask);
+        LOG.info("KAFKA-19148 TASK CREATION: Created INTER_BROKER_REPLICA_ACTION task {} for partition {} with proposal: {} -> {}, " +
+                 "oldLeader={}, newLeader={}, current cluster state - leader={}, ISR={}, replicas={}",
+                 replicaActionExecutionId, proposal.topicPartition(),
+                 proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
+                 proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
+                 proposal.oldLeader().brokerId(),
+                 proposal.newLeader().brokerId(),
+                 partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
+                 Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
+                 Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList()));
         LOG.trace("Added action {} as replica proposal {}", replicaActionExecutionId, proposal);
       }
     }
@@ -254,32 +264,63 @@ public class ExecutionTaskPlanner {
   private boolean wouldCauseUncleanLeaderElection(ExecutionProposal proposal, PartitionInfo partitionInfo) {
     // Get current leader
     if (partitionInfo.leader() == null) {
-      return false; // No leader, can't cause unclean election
+      LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing proposal",
+               proposal.topicPartition());
+      return false;
     }
     int currentLeader = partitionInfo.leader().id();
 
-    // Check if current leader is being removed from replica set
+    // Get current ISR
+    Set<Integer> currentIsr = Arrays.stream(partitionInfo.inSyncReplicas())
+        .map(Node::id)
+        .collect(Collectors.toSet());
+
+    // Get proposed replica set
     Set<Integer> proposedReplicas = proposal.newReplicas().stream()
         .map(ReplicaPlacementInfo::brokerId)
         .collect(Collectors.toSet());
 
+    // Log the check details
+    LOG.info("KAFKA-19148 check for partition {}: current leader={}, current ISR={}, " +
+             "proposed replicas={}, old replicas={}",
+             proposal.topicPartition(), currentLeader, currentIsr, proposedReplicas,
+             proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()));
+
+    // Check if current leader is being removed from replica set
     if (!proposedReplicas.contains(currentLeader)) {
       // Current leader being removed - check if ALL proposed replicas are in ISR
-      Set<Integer> currentIsr = Arrays.stream(partitionInfo.inSyncReplicas())
-          .map(Node::id)
-          .collect(Collectors.toSet());
+      boolean allProposedReplicasInIsr = proposedReplicas.stream().allMatch(currentIsr::contains);
 
-      // Check if ANY proposed replica is NOT in ISR
-      boolean hasNonIsrMember = proposedReplicas.stream()
-          .anyMatch(replica -> !currentIsr.contains(replica));
+      if (!allProposedReplicasInIsr) {
+        // Find which replicas are not in ISR
+        Set<Integer> nonIsrReplicas = proposedReplicas.stream()
+            .filter(replica -> !currentIsr.contains(replica))
+            .collect(Collectors.toSet());
 
-      if (hasNonIsrMember) {
-        // At least one non-ISR replica in new set - KRaft might elect it as leader
-        return true;
+        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - removing current leader {} " +
+                 "while non-ISR replicas {} would remain in replica set. Current ISR: {}",
+                 proposal.topicPartition(), currentLeader, nonIsrReplicas, currentIsr);
+        return true; // Would cause unclean election
       }
+
+      LOG.info("KAFKA-19148 check: Proposal for partition {} is safe - removing leader {} " +
+               "and all remaining replicas {} are in ISR",
+               proposal.topicPartition(), currentLeader, proposedReplicas);
+    } else {
+      // Leader not being removed - check if new leader would be in ISR
+      if (proposal.newLeader().brokerId() != currentLeader &&
+          !currentIsr.contains(proposal.newLeader().brokerId())) {
+        LOG.warn("KAFKA-19148 BLOCKED: Skipping proposal for partition {} - new leader {} is not in ISR. " +
+                 "Current leader: {}, current ISR: {}",
+                 proposal.topicPartition(), proposal.newLeader().brokerId(), currentLeader, currentIsr);
+        return true; // Would cause unclean election
+      }
+
+      LOG.info("KAFKA-19148 check: Proposal for partition {} is safe - leader remains or new leader is in ISR",
+               proposal.topicPartition());
     }
 
-    return false;
+    return false; // Safe to proceed
   }
 
   /**
@@ -316,6 +357,8 @@ public class ExecutionTaskPlanner {
             ExecutionTask task = new ExecutionTask(replicaActionExecutionId, proposal, r.brokerId(), INTRA_BROKER_REPLICA_ACTION,
                                                    Math.max(Math.round(proposal.dataToMoveInMB() / _intraBrokerReplicaMovementRateAlertingThreshold),
                                                             _taskExecutionAlertingThresholdMs));
+            LOG.info("Created INTRA_BROKER_REPLICA_ACTION task {} for partition {} on broker {} moving from {} to {}",
+                     replicaActionExecutionId, proposal.topicPartition(), r.brokerId(), currentLogdir, r.logdir());
             _intraPartMoveTasksByBrokerId.putIfAbsent(r.brokerId(), new TreeSet<>());
             _intraPartMoveTasksByBrokerId.get(r.brokerId()).add(task);
             _remainingIntraBrokerReplicaMovements.add(task);
@@ -341,6 +384,12 @@ public class ExecutionTaskPlanner {
           long leaderActionExecutionId = _executionId++;
           ExecutionTask leaderActionTask = new ExecutionTask(leaderActionExecutionId, proposal, LEADER_ACTION, _taskExecutionAlertingThresholdMs);
           _remainingLeadershipMovements.put(leaderActionExecutionId, leaderActionTask);
+          LOG.info("KAFKA-19148 TASK CREATION: Created LEADER_ACTION task {} for partition {} moving leadership from {} to {}, " +
+                   "current cluster state - leader={}, ISR={}, replicas={}",
+                   leaderActionExecutionId, proposal.topicPartition(), currentLeader.id(), proposal.newLeader().brokerId(),
+                   currentLeader.id(),
+                   Arrays.stream(cluster.partition(proposal.topicPartition()).inSyncReplicas()).map(Node::id).collect(Collectors.toList()),
+                   Arrays.stream(cluster.partition(proposal.topicPartition()).replicas()).map(Node::id).collect(Collectors.toList()));
           LOG.trace("Added action {} as leader proposal {}", leaderActionExecutionId, proposal);
         }
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -13,6 +13,7 @@ import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrateg
 import com.linkedin.kafka.cruisecontrol.executor.strategy.StrategyOptions;
 import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -190,6 +191,35 @@ public class ExecutionTaskPlanner {
         LOG.trace("Ignored the attempt to move non-existing partition for topic partition: {}", tp);
         continue;
       }
+
+      // Log current state vs proposal for debugging
+      if (LOG.isDebugEnabled()) {
+        Set<Integer> currentReplicas = Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toSet());
+        Set<Integer> currentIsr = Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toSet());
+        Set<Integer> proposedReplicas = proposal.newReplicas().stream()
+            .map(ReplicaPlacementInfo::brokerId)
+            .collect(Collectors.toSet());
+
+        LOG.debug("Evaluating proposal for partition {}: current replicas={}, ISR={}, leader={}, " +
+                  "proposal: {} -> {}, oldLeader={}, newLeader={}",
+                  tp, currentReplicas, currentIsr,
+                  partitionInfo.leader() != null ? partitionInfo.leader().id() : "null",
+                  proposal.oldReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList()),
+                  proposedReplicas,
+                  proposal.oldLeader().brokerId(),
+                  proposal.newLeader().brokerId());
+      }
+
+      // KAFKA-19148 validation: Check if the proposal would cause unclean leader election
+      if (wouldCauseUncleanLeaderElection(proposal, partitionInfo)) {
+        LOG.warn("Skipping proposal for partition {} to prevent KAFKA-19148: moving leader {} to broker {} " +
+                 "which would cause unclean election. Current replicas: {}, ISR: {}",
+                 tp, proposal.oldLeader().brokerId(), proposal.newLeader().brokerId(),
+                 Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList()),
+                 Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList()));
+        continue;
+      }
+
       if (!proposal.isInterBrokerMovementCompleted(partitionInfo)) {
         long replicaActionExecutionId = _executionId++;
         long executionAlertingThresholdMs = Math.max(Math.round(proposal.dataToMoveInMB() / _interBrokerReplicaMovementRateAlertingThreshold * 1000),
@@ -206,6 +236,50 @@ public class ExecutionTaskPlanner {
                                                                 : replicaMovementStrategy.chainBaseReplicaMovementStrategyIfAbsent();
     _interPartMoveTasksByBrokerId = chosenReplicaMovementTaskStrategy.applyStrategy(_remainingInterBrokerReplicaMovements, strategyOptions);
     _interPartMoveBrokerComparator = brokerComparator(strategyOptions, chosenReplicaMovementTaskStrategy);
+  }
+
+  /**
+   * Check if executing this proposal would cause an unclean leader election (KAFKA-19148).
+   * In KRaft mode, when the current leader is removed from the replica set, Kafka might
+   * elect a non-ISR replica as leader even when ISR members are available in the new set.
+   *
+   * To prevent this, we skip any proposal that:
+   * 1. Removes the current leader from the replica set AND
+   * 2. Has ANY non-ISR replicas in the new replica set
+   *
+   * @param proposal The execution proposal to check
+   * @param partitionInfo Current partition state from Kafka cluster
+   * @return true if this proposal would cause unclean leader election, false otherwise
+   */
+  private boolean wouldCauseUncleanLeaderElection(ExecutionProposal proposal, PartitionInfo partitionInfo) {
+    // Get current leader
+    if (partitionInfo.leader() == null) {
+      return false; // No leader, can't cause unclean election
+    }
+    int currentLeader = partitionInfo.leader().id();
+
+    // Check if current leader is being removed from replica set
+    Set<Integer> proposedReplicas = proposal.newReplicas().stream()
+        .map(ReplicaPlacementInfo::brokerId)
+        .collect(Collectors.toSet());
+
+    if (!proposedReplicas.contains(currentLeader)) {
+      // Current leader being removed - check if ALL proposed replicas are in ISR
+      Set<Integer> currentIsr = Arrays.stream(partitionInfo.inSyncReplicas())
+          .map(Node::id)
+          .collect(Collectors.toSet());
+
+      // Check if ANY proposed replica is NOT in ISR
+      boolean hasNonIsrMember = proposedReplicas.stream()
+          .anyMatch(replica -> !currentIsr.contains(replica));
+
+      if (hasNonIsrMember) {
+        // At least one non-ISR replica in new set - KRaft might elect it as leader
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -621,9 +621,11 @@ public final class ExecutionUtils {
 
     List<ExecutionTask> safeTasks = filterKafka19148UnsafeTasks(adminClient, tasks);
     if (safeTasks.isEmpty()) {
-      LOG.error("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}",
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}. " +
+               "Returning empty result - no tasks will be executed.",
                 tasks.size(), tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
-      throw new IllegalArgumentException("All tasks were filtered out by KAFKA-19148 safety check.");
+      // Return an empty result instead of throwing exception - this allows execution to complete gracefully
+      return adminClient.alterPartitionReassignments(Collections.emptyMap());
     }
 
     if (safeTasks.size() < tasks.size()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,22 +27,26 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.clients.admin.ListPartitionReassignmentsResult;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.PartitionReassignment;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -436,7 +441,113 @@ public final class ExecutionUtils {
   }
 
   /**
+   * Validates tasks against KAFKA-19148 before submission.
+   * This is a final safety check to prevent unclean leader elections.
+   *
+   * @param adminClient The admin client to get current cluster state.
+   * @param tasks The tasks to validate.
+   * @return List of tasks that are safe to execute.
+   */
+  private static List<ExecutionTask> filterKafka19148UnsafeTasks(AdminClient adminClient, List<ExecutionTask> tasks) {
+    List<ExecutionTask> safeTasks = new ArrayList<>();
+
+    try {
+      // Get metadata for all topics involved
+      Set<String> topics = tasks.stream()
+          .map(task -> task.proposal().topicPartition().topic())
+          .collect(Collectors.toSet());
+
+      LOG.info("KAFKA-19148 check: Fetching current metadata for {} topics: {}", topics.size(), topics);
+      // TODO: assess the impact of this on the performance
+      DescribeTopicsResult topicsResult = adminClient.describeTopics(topics);
+      Map<String, TopicDescription> topicDescriptions =
+          topicsResult.allTopicNames().get(30, TimeUnit.SECONDS);
+      LOG.info("KAFKA-19148 check: Successfully retrieved metadata for {} topics", topicDescriptions.size());
+
+      for (ExecutionTask task : tasks) {
+        TopicPartition tp = task.proposal().topicPartition();
+        TopicDescription topicDesc = topicDescriptions.get(tp.topic());
+
+        if (topicDesc == null) {
+          LOG.warn("KAFKA-19148 check: Topic {} not found, skipping task {} for partition {}",
+                   tp.topic(), task.executionId(), tp);
+          continue;
+        }
+
+        TopicPartitionInfo partitionInfo = topicDesc.partitions().get(tp.partition());
+
+        // Check if this movement would trigger KAFKA-19148
+        Node currentLeader = partitionInfo.leader();
+        if (currentLeader == null) {
+          LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing task {} to proceed",
+                   tp, task.executionId());
+          safeTasks.add(task);
+          continue;
+        }
+
+        // Get current ISR
+        Set<Integer> currentIsrIds = partitionInfo.isr().stream()
+            .map(Node::id)
+            .collect(Collectors.toSet());
+
+        // Get proposed replica set
+        Set<Integer> proposedReplicaIds = task.proposal().newReplicas().stream()
+            .map(ReplicaPlacementInfo::brokerId)
+            .collect(Collectors.toSet());
+
+        LOG.info("KAFKA-19148 check: Validating task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
+                 task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
+
+        // Check if removing current leader
+        if (!proposedReplicaIds.contains(currentLeader.id())) {
+          LOG.info("KAFKA-19148 check: Task {} would remove current leader {} from partition {}",
+                   task.executionId(), currentLeader.id(), tp);
+          // Current leader being removed - check if ALL proposed replicas are in ISR
+          boolean allProposedReplicasInIsr = proposedReplicaIds.stream()
+              .allMatch(currentIsrIds::contains);
+
+          if (!allProposedReplicasInIsr) {
+            Set<Integer> nonIsrReplicas = proposedReplicaIds.stream()
+                .filter(id -> !currentIsrIds.contains(id))
+                .collect(Collectors.toSet());
+
+            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - " +
+                     "removing current leader {} while non-ISR replicas {} would remain in replica set. " +
+                     "Current ISR: {}, proposed replicas: {}",
+                     task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds, proposedReplicaIds);
+            // Skip this task
+            continue;
+          }
+
+          LOG.info("KAFKA-19148 check: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
+                   task.executionId(), currentLeader.id(), proposedReplicaIds);
+        } else {
+          LOG.info("KAFKA-19148 check: Task {} is safe - leader {} remains in proposed replica set",
+                   task.executionId(), currentLeader.id());
+        }
+
+        LOG.info("KAFKA-19148 execution-time check: Task {} for partition {} is SAFE to execute",
+                 task.executionId(), tp);
+        safeTasks.add(task);
+      }
+
+    } catch (Exception e) {
+      LOG.error("KAFKA-19148 check: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. " +
+                "Tasks: {}, Error: {}", tasks.size(),
+                tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(), t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
+                e.getMessage(), e);
+      // In case of error, be conservative and block all tasks to prevent KAFKA-19148
+      return Collections.emptyList();
+    }
+
+    return safeTasks;
+  }
+
+  /**
    * Submits the given inter-broker replica reassignment tasks for execution using the given admin client.
+   *
+   * This method includes KAFKA-19148 safety checks to prevent unclean leader elections.
+   * All tasks are validated against current cluster state before submission.
    *
    * @param adminClient The adminClient to submit new inter-broker replica reassignments.
    * @param tasks Inter-broker replica reassignment tasks to execute.
@@ -447,9 +558,34 @@ public final class ExecutionUtils {
       throw new IllegalArgumentException("Tasks to execute cannot be empty.");
     }
 
+    // KAFKA-19148 protection: Filter out potentially unsafe tasks
+    LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: Validating {} tasks for safety before submission", tasks.size());
+    for (ExecutionTask task : tasks) {
+      LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: Validating task {} for partition {} (state: {}, proposal: {} -> {})",
+               task.executionId(), task.proposal().topicPartition(), task.state(),
+               task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+               task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
+    }
+
+    List<ExecutionTask> safeTasks = filterKafka19148UnsafeTasks(adminClient, tasks);
+    if (safeTasks.isEmpty()) {
+      LOG.error("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}",
+                tasks.size(), tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+      throw new IllegalArgumentException("All tasks were filtered out by KAFKA-19148 safety check.");
+    }
+
+    if (safeTasks.size() < tasks.size()) {
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, Filtered tasks: {}",
+               tasks.size() - safeTasks.size(), tasks.size(),
+               safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
+               tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+    } else {
+      LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());
+    }
+
     // Update the ongoing replica reassignments in case the task status has changed.
     Map<TopicPartition, Optional<NewPartitionReassignment>> newReassignments = new HashMap<>();
-    for (ExecutionTask task : tasks) {
+    for (ExecutionTask task : safeTasks) {
       TopicPartition tp = task.proposal().topicPartition();
       List<Integer> newReplicas = new ArrayList<>(task.proposal().newReplicas().size());
       for (ReplicaPlacementInfo replicaPlacementInfo : task.proposal().newReplicas()) {
@@ -472,6 +608,8 @@ public final class ExecutionUtils {
           // Likewise, no need to check if there is already an ongoing execution for the partition, because if one
           // exists, it will be modified to execute the desired task.
           newReassignments.put(tp, reassignmentValue(newReplicas));
+          LOG.info("Submitting IN_PROGRESS task {} for execution: partition={}, newReplicas={}",
+                   task.executionId(), tp, newReplicas);
           LOG.debug("Task {} will be executed.", task);
           break;
         default:

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -441,19 +441,41 @@ public final class ExecutionUtils {
   }
 
   /**
+   * Result of filtering tasks for KAFKA-19148 safety.
+   */
+  static class Kafka19148FilterResult {
+    private final List<ExecutionTask> safeTasks;
+    private final List<ExecutionTask> completedTasks;
+
+    Kafka19148FilterResult(List<ExecutionTask> safeTasks, List<ExecutionTask> completedTasks) {
+      this.safeTasks = safeTasks;
+      this.completedTasks = completedTasks;
+    }
+
+    List<ExecutionTask> getSafeTasks() {
+      return safeTasks;
+    }
+
+    List<ExecutionTask> getCompletedTasks() {
+      return completedTasks;
+    }
+  }
+
+  /**
    * Filters out KAFKA-19148 unsafe tasks from the given list of tasks.
    *
    * @param adminClient The admin client to use for fetching cluster metadata.
    * @param tasks The list of tasks to filter.
-   * @return The list of safe tasks that can be executed.
+   * @return The filtering result containing safe tasks to execute and completed tasks.
    */
-  private static List<ExecutionTask> filterKafka19148UnsafeTasks(AdminClient adminClient,
-                                                                  List<ExecutionTask> tasks) {
+  static Kafka19148FilterResult filterKafka19148UnsafeTasks(AdminClient adminClient,
+                                                             List<ExecutionTask> tasks) {
     if (tasks.isEmpty()) {
-      return tasks;
+      return new Kafka19148FilterResult(tasks, Collections.emptyList());
     }
 
     List<ExecutionTask> safeTasks = new ArrayList<>();
+    List<ExecutionTask> completedTasks = new ArrayList<>();
 
     try {
       // Get current cluster metadata for all topics involved
@@ -502,11 +524,12 @@ public final class ExecutionUtils {
         // Check if this task is already complete but stuck due to replica ordering
         if (isTaskEffectivelyComplete(task, partitionInfo)) {
           LOG.warn("KAFKA-19148 REPLICA-ORDER-MISMATCH: Task {} for partition {} appears complete but stuck due to replica ordering. "
-                   + "Expected order: {}, Actual order: {}. Skipping to prevent stuck execution.",
+                   + "Expected order: {}, Actual order: {}. Marking as complete to prevent stuck execution.",
                    task.executionId(), tp,
                    task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
                    partitionInfo.replicas().stream().map(Node::id).collect(Collectors.toList()));
-          // Skip this task as it's effectively complete
+          // Mark this task as complete
+          completedTasks.add(task);
           continue;
         }
 
@@ -567,13 +590,13 @@ public final class ExecutionUtils {
                     t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
                 e.getMessage(), e);
       // In case of error, be conservative and block all tasks to prevent KAFKA-19148
-      return Collections.emptyList();
+      return new Kafka19148FilterResult(Collections.emptyList(), Collections.emptyList());
     }
 
-    LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation",
-              safeTasks.size(), tasks.size());
+    LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation, {} marked as complete",
+              safeTasks.size(), tasks.size(), completedTasks.size());
 
-    return safeTasks;
+    return new Kafka19148FilterResult(safeTasks, completedTasks);
   }
 
   /**
@@ -619,6 +642,23 @@ public final class ExecutionUtils {
    */
   public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient,
                                                                                  List<ExecutionTask> tasks) {
+    return submitReplicaReassignmentTasks(adminClient, tasks, null);
+  }
+
+  /**
+   * Submits the given inter-broker replica reassignment tasks for execution using the given admin client.
+   *
+   * This method includes KAFKA-19148 safety checks to prevent unclean leader elections.
+   * All tasks are validated against current cluster state before submission.
+   *
+   * @param adminClient The adminClient to submit new inter-broker replica reassignments.
+   * @param tasks Inter-broker replica reassignment tasks to execute.
+   * @param tasksToMarkComplete Optional list to populate with tasks that should be marked as complete.
+   * @return The {@link AlterPartitionReassignmentsResult result} of reassignment request -- cannot be {@code null}.
+   */
+  public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient,
+                                                                                 List<ExecutionTask> tasks,
+                                                                                 List<ExecutionTask> tasksToMarkComplete) {
     if (validateNotNull(tasks, "Tasks to execute cannot be null.").isEmpty()) {
       throw new IllegalArgumentException("Tasks to execute cannot be empty.");
     }
@@ -632,25 +672,40 @@ public final class ExecutionUtils {
                 task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
     }
 
-    List<ExecutionTask> safeTasks = filterKafka19148UnsafeTasks(adminClient, tasks);
+    Kafka19148FilterResult filterResult = filterKafka19148UnsafeTasks(adminClient, tasks);
+    List<ExecutionTask> safeTasks = filterResult.getSafeTasks();
+    List<ExecutionTask> completedTasks = filterResult.getCompletedTasks();
+    
+    // If caller wants to know about completed tasks, populate the list
+    if (tasksToMarkComplete != null && !completedTasks.isEmpty()) {
+      tasksToMarkComplete.addAll(completedTasks);
+    }
+    
+    if (!completedTasks.isEmpty()) {
+      LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} tasks are already complete (replica ordering mismatch). "
+               + "These will be marked as complete: {}",
+               completedTasks.size(),
+               completedTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
+                   t.proposal().topicPartition())).collect(Collectors.toList()));
+    }
+    
     if (safeTasks.isEmpty()) {
-      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}. "
-               + "Returning empty result - no tasks will be executed.",
-                tasks.size(), tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. "
+               + "{} marked as complete, {} blocked. Original tasks: {}. "
+               + "Returning empty result - no new tasks will be executed.",
+                tasks.size(), completedTasks.size(), tasks.size() - completedTasks.size(),
+                tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
                     t.proposal().topicPartition())).collect(Collectors.toList()));
       // Return an empty result instead of throwing exception - this allows execution to complete gracefully
       return adminClient.alterPartitionReassignments(Collections.emptyMap());
     }
 
     if (safeTasks.size() < tasks.size()) {
-      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, "
-               + "Filtered tasks: {}",
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered {} tasks out of {} total. "
+               + "Safe tasks: {}, Completed tasks: {}, Blocked tasks: {}",
                tasks.size() - safeTasks.size(), tasks.size(),
-               safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
-                   t.proposal().topicPartition())).collect(Collectors.toList()),
-               tasks.stream().filter(t -> !safeTasks.contains(t))
-                   .map(t -> String.format("Task-%d:%s", t.executionId(),
-                       t.proposal().topicPartition())).collect(Collectors.toList()));
+               safeTasks.size(), completedTasks.size(), 
+               tasks.size() - safeTasks.size() - completedTasks.size());
     } else {
       LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
@@ -444,25 +445,26 @@ public final class ExecutionUtils {
    * Result of filtering tasks for KAFKA-19148 safety.
    */
   static class Kafka19148FilterResult {
-    private final List<ExecutionTask> safeTasks;
-    private final List<ExecutionTask> completedTasks;
+    private final List<ExecutionTask> _safeTasks;
+    private final List<ExecutionTask> _completedTasks;
 
     Kafka19148FilterResult(List<ExecutionTask> safeTasks, List<ExecutionTask> completedTasks) {
-      this.safeTasks = safeTasks;
-      this.completedTasks = completedTasks;
+      this._safeTasks = safeTasks;
+      this._completedTasks = completedTasks;
     }
 
     List<ExecutionTask> getSafeTasks() {
-      return safeTasks;
+      return _safeTasks;
     }
 
     List<ExecutionTask> getCompletedTasks() {
-      return completedTasks;
+      return _completedTasks;
     }
   }
 
   /**
    * Filters out KAFKA-19148 unsafe tasks from the given list of tasks.
+   * Also validates that the filtered tasks don't violate hard goals, particularly rack awareness.
    *
    * @param adminClient The admin client to use for fetching cluster metadata.
    * @param tasks The list of tasks to filter.
@@ -476,6 +478,7 @@ public final class ExecutionUtils {
 
     List<ExecutionTask> safeTasks = new ArrayList<>();
     List<ExecutionTask> completedTasks = new ArrayList<>();
+    Map<String, TopicDescription> topicDescriptions = null;
 
     try {
       // Get current cluster metadata for all topics involved
@@ -487,17 +490,16 @@ public final class ExecutionUtils {
                 topicsToCheck.size(), topicsToCheck);
 
       DescribeTopicsResult describeResult = adminClient.describeTopics(topicsToCheck);
-      Map<String, TopicDescription> topicDescriptions = describeResult.all().get(30, TimeUnit.SECONDS);
+      topicDescriptions = describeResult.all().get(30, TimeUnit.SECONDS);
 
-      LOG.debug("KAFKA-19148 check: Successfully retrieved metadata for {} topics",
-                topicDescriptions.size());
+      LOG.debug("KAFKA-19148 check: Successfully retrieved topic metadata");
 
       for (ExecutionTask task : tasks) {
         TopicPartition tp = task.proposal().topicPartition();
         TopicDescription topicDesc = topicDescriptions.get(tp.topic());
 
         if (topicDesc == null) {
-          LOG.warn("KAFKA-19148 check: Topic {} not found in metadata, skipping task {}",
+          LOG.debug("KAFKA-19148 check: Topic {} not found in metadata, skipping task {}",
                    tp.topic(), task.executionId());
           continue;
         }
@@ -509,14 +511,14 @@ public final class ExecutionUtils {
             .orElse(null);
 
         if (partitionInfo == null) {
-          LOG.warn("KAFKA-19148 check: Partition {} not found in topic metadata, skipping task {}",
+          LOG.debug("KAFKA-19148 check: Partition {} not found in topic metadata, skipping task {}",
                    tp, task.executionId());
           continue;
         }
 
         Node currentLeader = partitionInfo.leader();
         if (currentLeader == null) {
-          LOG.warn("KAFKA-19148 check: Partition {} has no leader, skipping task {}",
+          LOG.debug("KAFKA-19148 check: Partition {} has no leader, skipping task {}",
                    tp, task.executionId());
           continue;
         }
@@ -560,7 +562,7 @@ public final class ExecutionUtils {
                 .filter(id -> !currentIsrIds.contains(id))
                 .collect(Collectors.toSet());
 
-            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - removing current leader {} "
+            LOG.debug("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - removing current leader {} "
                      + "while proposed replicas {} are not in ISR. Current ISR: {}. This could lead to unclean leader election.",
                      task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds);
             // Skip this unsafe task
@@ -596,7 +598,162 @@ public final class ExecutionUtils {
     LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation, {} marked as complete",
               safeTasks.size(), tasks.size(), completedTasks.size());
 
+    // Additional validation: Ensure filtered tasks don't violate rack awareness
+    // Only remove tasks that would actually cause rack awareness violations
+    // Note: topicDescriptions will be empty if we caught an exception above
+    safeTasks = validateRackAwarenessForFilteredTasks(adminClient, safeTasks, tasks,
+                                                      topicDescriptions != null ? topicDescriptions : new HashMap<>());
+
     return new Kafka19148FilterResult(safeTasks, completedTasks);
+  }
+
+  /**
+   * Validates that the filtered tasks don't violate rack awareness constraints.
+   * This prevents scenarios where blocking some tasks causes remaining tasks to place
+   * multiple replicas of the same partition in the same rack/zone.
+   *
+   * @param adminClient The admin client to use for fetching rack information.
+   * @param safeTasks The tasks that passed KAFKA-19148 safety checks.
+   * @param allTasks All tasks that were originally submitted.
+   * @param topicDescriptions Topic metadata containing current replica assignments.
+   * @return List of tasks that are safe to execute without violating rack awareness.
+   */
+  private static List<ExecutionTask> validateRackAwarenessForFilteredTasks(AdminClient adminClient,
+                                                                           List<ExecutionTask> safeTasks,
+                                                                           List<ExecutionTask> allTasks,
+                                                                           Map<String, TopicDescription> topicDescriptions) {
+    if (safeTasks.isEmpty() || safeTasks.size() == allTasks.size()) {
+      // Nothing to validate if no tasks were filtered or all tasks are safe
+      return safeTasks;
+    }
+
+    try {
+      // Get broker rack information
+      DescribeClusterResult clusterResult = adminClient.describeCluster();
+      Collection<Node> nodes = clusterResult.nodes().get(30, TimeUnit.SECONDS);
+
+      // Build broker ID to rack mapping
+      Map<Integer, String> brokerRacks = new HashMap<>();
+      for (Node node : nodes) {
+        if (node.rack() != null) {
+          brokerRacks.put(node.id(), node.rack());
+        }
+      }
+
+      // If no rack information available, can't validate rack awareness
+      if (brokerRacks.isEmpty()) {
+        LOG.debug("No rack information available, skipping rack awareness validation");
+        return safeTasks;
+      }
+
+      // Group tasks by partition
+      Map<TopicPartition, List<ExecutionTask>> allTasksByPartition = allTasks.stream()
+          .collect(Collectors.groupingBy(task -> task.proposal().topicPartition()));
+
+      Map<TopicPartition, List<ExecutionTask>> safeTasksByPartition = safeTasks.stream()
+          .collect(Collectors.groupingBy(task -> task.proposal().topicPartition()));
+
+      List<ExecutionTask> finalSafeTasks = new ArrayList<>();
+
+      // Check each partition's tasks
+      for (Map.Entry<TopicPartition, List<ExecutionTask>> entry : safeTasksByPartition.entrySet()) {
+        TopicPartition tp = entry.getKey();
+        List<ExecutionTask> partitionSafeTasks = entry.getValue();
+        List<ExecutionTask> partitionAllTasks = allTasksByPartition.get(tp);
+
+        // Get current replica placement
+        TopicDescription topicDesc = topicDescriptions.get(tp.topic());
+        if (topicDesc == null) {
+          continue;
+        }
+
+        TopicPartitionInfo partitionInfo = topicDesc.partitions().stream()
+            .filter(p -> p.partition() == tp.partition())
+            .findFirst()
+            .orElse(null);
+
+        if (partitionInfo == null) {
+          continue;
+        }
+
+        // Calculate the final replica placement after applying only the safe tasks
+        Map<Integer, String> finalReplicaRacks = calculateFinalReplicaRacks(
+            partitionInfo, partitionSafeTasks, partitionAllTasks, brokerRacks);
+
+        // Check if final placement violates rack awareness
+        if (violatesRackAwareness(finalReplicaRacks)) {
+          LOG.warn("RACK AWARENESS VIOLATION: Partition {} would have multiple replicas in the same rack after "
+                   + "applying filtered tasks. Blocking all {} tasks for this partition. Final rack distribution: {}",
+                   tp, partitionSafeTasks.size(), finalReplicaRacks);
+          // Don't add these tasks to finalSafeTasks
+        } else {
+          finalSafeTasks.addAll(partitionSafeTasks);
+        }
+      }
+
+      if (finalSafeTasks.size() < safeTasks.size()) {
+        LOG.info("RACK AWARENESS VALIDATION: Removed {} tasks that would violate rack awareness. "
+                 + "Final safe tasks: {} out of {} originally safe tasks",
+                 safeTasks.size() - finalSafeTasks.size(), finalSafeTasks.size(), safeTasks.size());
+      }
+
+      return finalSafeTasks;
+
+    } catch (Exception e) {
+      LOG.warn("Failed to validate rack awareness for filtered tasks. Being conservative and blocking all tasks. Error: ",
+                e);
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Calculates the final rack distribution after applying the safe tasks.
+   *
+   * @param currentPartitionInfo Current partition information.
+   * @param safeTasks Tasks that passed KAFKA-19148 safety checks.
+   * @param allTasks All tasks that were originally submitted.
+   * @param brokerRacks Mapping of broker IDs to rack names.
+   * @return Map of broker ID to rack name for the final replica placement.
+   */
+  private static Map<Integer, String> calculateFinalReplicaRacks(TopicPartitionInfo currentPartitionInfo,
+                                                                 List<ExecutionTask> safeTasks,
+                                                                 List<ExecutionTask> allTasks,
+                                                                 Map<Integer, String> brokerRacks) {
+    // Start with current replica placement
+    Map<Integer, String> replicaRacks = new HashMap<>();
+    for (Node replica : currentPartitionInfo.replicas()) {
+      String rack = brokerRacks.get(replica.id());
+      if (rack != null) {
+        replicaRacks.put(replica.id(), rack);
+      }
+    }
+
+    // Apply the safe tasks to see the final state
+    for (ExecutionTask task : safeTasks) {
+      for (ReplicaPlacementInfo oldReplica : task.proposal().oldReplicas()) {
+        replicaRacks.remove(oldReplica.brokerId());
+      }
+
+      for (ReplicaPlacementInfo newReplica : task.proposal().newReplicas()) {
+        String rack = brokerRacks.get(newReplica.brokerId());
+        if (rack != null) {
+          replicaRacks.put(newReplica.brokerId(), rack);
+        }
+      }
+    }
+
+    return replicaRacks;
+  }
+
+  /**
+   * Checks if the given rack distribution violates rack awareness.
+   *
+   * @param replicaRacks Map of broker ID to rack name for replica placement.
+   * @return true if rack awareness is violated (multiple replicas in same rack), false otherwise.
+   */
+  private static boolean violatesRackAwareness(Map<Integer, String> replicaRacks) {
+    Set<String> uniqueRacks = new HashSet<>(replicaRacks.values());
+    return uniqueRacks.size() < replicaRacks.size();
   }
 
   /**
@@ -677,12 +834,12 @@ public final class ExecutionUtils {
     Kafka19148FilterResult filterResult = filterKafka19148UnsafeTasks(adminClient, tasks);
     List<ExecutionTask> safeTasks = filterResult.getSafeTasks();
     List<ExecutionTask> completedTasks = filterResult.getCompletedTasks();
-    
+
     // If caller wants to know about completed tasks, populate the list
     if (tasksToMarkComplete != null && !completedTasks.isEmpty()) {
       tasksToMarkComplete.addAll(completedTasks);
     }
-    
+
     if (!completedTasks.isEmpty()) {
       LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} tasks are already complete (replica ordering mismatch). "
                + "These will be marked as complete: {}",
@@ -690,13 +847,13 @@ public final class ExecutionUtils {
                completedTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
                    t.proposal().topicPartition())).collect(Collectors.toList()));
     }
-    
+
     // Identify unsafe tasks that should be marked as DEAD
     if (safeTasks.size() < tasks.size() || !completedTasks.isEmpty()) {
       Set<ExecutionTask> unsafeTasks = new HashSet<>(tasks);
       unsafeTasks.removeAll(safeTasks);
-      unsafeTasks.removeAll(completedTasks); // Don't mark completed ones as DEAD
-      
+      unsafeTasks.removeAll(completedTasks);
+
       if (!unsafeTasks.isEmpty() && tasksToMarkDead != null) {
         tasksToMarkDead.addAll(unsafeTasks);
         LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} tasks are unsafe (would cause unclean leader election). "
@@ -706,7 +863,7 @@ public final class ExecutionUtils {
                      t.proposal().topicPartition())).collect(Collectors.toList()));
       }
     }
-    
+
     if (safeTasks.isEmpty()) {
       LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. "
                + "{} marked as complete, {} marked as dead. Original tasks: {}. "
@@ -722,7 +879,7 @@ public final class ExecutionUtils {
       LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered {} tasks out of {} total. "
                + "Safe tasks: {}, Completed tasks: {}, Blocked tasks: {}",
                tasks.size() - safeTasks.size(), tasks.size(),
-               safeTasks.size(), completedTasks.size(), 
+               safeTasks.size(), completedTasks.size(),
                tasks.size() - safeTasks.size() - completedTasks.size());
     } else {
       LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -441,47 +441,69 @@ public final class ExecutionUtils {
   }
 
   /**
-   * Validates tasks against KAFKA-19148 before submission.
-   * This is a final safety check to prevent unclean leader elections.
-   *
-   * @param adminClient The admin client to get current cluster state.
-   * @param tasks The tasks to validate.
-   * @return List of tasks that are safe to execute.
+   * Filter out tasks that might cause KAFKA-19148 unclean leader elections.
+   * This method validates tasks against the current cluster state before execution.
    */
-  private static List<ExecutionTask> filterKafka19148UnsafeTasks(AdminClient adminClient, List<ExecutionTask> tasks) {
+  private static List<ExecutionTask> filterKafka19148UnsafeTasks(AdminClient adminClient,
+                                                                  List<ExecutionTask> tasks) {
+    if (tasks.isEmpty()) {
+      return tasks;
+    }
+
     List<ExecutionTask> safeTasks = new ArrayList<>();
 
     try {
-      // Get metadata for all topics involved
-      Set<String> topics = tasks.stream()
+      // Get current cluster metadata for all topics involved
+      Set<String> topicsToCheck = tasks.stream()
           .map(task -> task.proposal().topicPartition().topic())
           .collect(Collectors.toSet());
 
-      LOG.info("KAFKA-19148 check: Fetching current metadata for {} topics: {}", topics.size(), topics);
-      // TODO: assess the impact of this on the performance
-      DescribeTopicsResult topicsResult = adminClient.describeTopics(topics);
-      Map<String, TopicDescription> topicDescriptions =
-          topicsResult.allTopicNames().get(30, TimeUnit.SECONDS);
-      LOG.info("KAFKA-19148 check: Successfully retrieved metadata for {} topics", topicDescriptions.size());
+      LOG.info("KAFKA-19148 check: Fetching current metadata for {} topics: {}",
+               topicsToCheck.size(), topicsToCheck);
+
+      DescribeTopicsResult describeResult = adminClient.describeTopics(topicsToCheck);
+      Map<String, TopicDescription> topicDescriptions = describeResult.all().get(30, TimeUnit.SECONDS);
+
+      LOG.info("KAFKA-19148 check: Successfully retrieved metadata for {} topics",
+               topicDescriptions.size());
 
       for (ExecutionTask task : tasks) {
         TopicPartition tp = task.proposal().topicPartition();
         TopicDescription topicDesc = topicDescriptions.get(tp.topic());
 
         if (topicDesc == null) {
-          LOG.warn("KAFKA-19148 check: Topic {} not found, skipping task {} for partition {}",
-                   tp.topic(), task.executionId(), tp);
+          LOG.warn("KAFKA-19148 check: Topic {} not found in metadata, skipping task {}",
+                   tp.topic(), task.executionId());
           continue;
         }
 
-        TopicPartitionInfo partitionInfo = topicDesc.partitions().get(tp.partition());
+        // Find the partition info
+        TopicPartitionInfo partitionInfo = topicDesc.partitions().stream()
+            .filter(p -> p.partition() == tp.partition())
+            .findFirst()
+            .orElse(null);
 
-        // Check if this movement would trigger KAFKA-19148
+        if (partitionInfo == null) {
+          LOG.warn("KAFKA-19148 check: Partition {} not found in topic metadata, skipping task {}",
+                   tp, task.executionId());
+          continue;
+        }
+
         Node currentLeader = partitionInfo.leader();
         if (currentLeader == null) {
-          LOG.info("KAFKA-19148 check: Partition {} has no leader, allowing task {} to proceed",
+          LOG.warn("KAFKA-19148 check: Partition {} has no leader, skipping task {}",
                    tp, task.executionId());
-          safeTasks.add(task);
+          continue;
+        }
+
+        // Check if this task is already complete but stuck due to replica ordering
+        if (isTaskEffectivelyComplete(task, partitionInfo)) {
+          LOG.warn("KAFKA-19148 REPLICA-ORDER-MISMATCH: Task {} for partition {} appears complete but stuck due to replica ordering. " +
+                   "Expected order: {}, Actual order: {}. Skipping to prevent stuck execution.",
+                   task.executionId(), tp,
+                   task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                   partitionInfo.replicas().stream().map(Node::id).collect(Collectors.toList()));
+          // Skip this task as it's effectively complete
           continue;
         }
 
@@ -499,10 +521,10 @@ public final class ExecutionUtils {
                  task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
 
         // Check if removing current leader
-        if (!proposedReplicaIds.contains(currentLeader.id())) {
-          LOG.info("KAFKA-19148 check: Task {} would remove current leader {} from partition {}",
-                   task.executionId(), currentLeader.id(), tp);
-          // Current leader being removed - check if ALL proposed replicas are in ISR
+        boolean removingCurrentLeader = !proposedReplicaIds.contains(currentLeader.id());
+
+        if (removingCurrentLeader) {
+          // When removing the current leader, ensure all proposed replicas are in ISR
           boolean allProposedReplicasInIsr = proposedReplicaIds.stream()
               .allMatch(currentIsrIds::contains);
 
@@ -511,24 +533,23 @@ public final class ExecutionUtils {
                 .filter(id -> !currentIsrIds.contains(id))
                 .collect(Collectors.toSet());
 
-            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - " +
-                     "removing current leader {} while non-ISR replicas {} would remain in replica set. " +
-                     "Current ISR: {}, proposed replicas: {}",
-                     task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds, proposedReplicaIds);
-            // Skip this task
+            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - removing current leader {} " +
+                     "while proposed replicas {} are not in ISR. Current ISR: {}. This could lead to unclean leader election.",
+                     task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds);
+            // Skip this unsafe task
             continue;
           }
 
-          LOG.info("KAFKA-19148 check: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
-                   task.executionId(), currentLeader.id(), proposedReplicaIds);
+          LOG.info("KAFKA-19148 check: Task {} is safe - all proposed replicas are in ISR when removing leader",
+                   task.executionId());
         } else {
           LOG.info("KAFKA-19148 check: Task {} is safe - leader {} remains in proposed replica set",
                    task.executionId(), currentLeader.id());
         }
 
+        safeTasks.add(task);
         LOG.info("KAFKA-19148 execution-time check: Task {} for partition {} is SAFE to execute",
                  task.executionId(), tp);
-        safeTasks.add(task);
       }
 
     } catch (Exception e) {
@@ -540,7 +561,37 @@ public final class ExecutionUtils {
       return Collections.emptyList();
     }
 
+    LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation",
+             safeTasks.size(), tasks.size());
+
     return safeTasks;
+  }
+
+  /**
+   * Checks if a task is effectively complete despite replica ordering differences.
+   * This handles cases where the replica set matches but the order doesn't.
+   */
+  private static boolean isTaskEffectivelyComplete(ExecutionTask task, TopicPartitionInfo partitionInfo) {
+    // Get the proposed and current replica sets (ignoring order)
+    Set<Integer> proposedReplicaSet = task.proposal().newReplicas().stream()
+        .map(ReplicaPlacementInfo::brokerId)
+        .collect(Collectors.toSet());
+
+    Set<Integer> currentReplicaSet = partitionInfo.replicas().stream()
+        .map(Node::id)
+        .collect(Collectors.toSet());
+
+    // Check if sets match (ignoring order) and all replicas are in ISR
+    if (proposedReplicaSet.equals(currentReplicaSet)) {
+      Set<Integer> currentIsrSet = partitionInfo.isr().stream()
+          .map(Node::id)
+          .collect(Collectors.toSet());
+
+      // If all replicas are in ISR, the task is effectively complete
+      return currentReplicaSet.equals(currentIsrSet);
+    }
+
+    return false;
   }
 
   /**
@@ -553,7 +604,8 @@ public final class ExecutionUtils {
    * @param tasks Inter-broker replica reassignment tasks to execute.
    * @return The {@link AlterPartitionReassignmentsResult result} of reassignment request -- cannot be {@code null}.
    */
-  public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient, List<ExecutionTask> tasks) {
+  public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient,
+                                                                                 List<ExecutionTask> tasks) {
     if (validateNotNull(tasks, "Tasks to execute cannot be null.").isEmpty()) {
       throw new IllegalArgumentException("Tasks to execute cannot be empty.");
     }
@@ -620,6 +672,7 @@ public final class ExecutionUtils {
     if (newReassignments.isEmpty()) {
       throw new IllegalArgumentException("All tasks submitted for replica reassignment are already completed.");
     }
+
     return adminClient.alterPartitionReassignments(newReassignments);
   }
 
@@ -670,6 +723,15 @@ public final class ExecutionUtils {
 
     if (!tasksToReexecute.isEmpty()) {
       LOG.info("Found tasks to re-execute: {} while detected in-movement partitions: {}.", tasksToReexecute, partitionsInMovement);
+      // Add detailed logging for KAFKA-19148 debugging
+      for (ExecutionTask task : tasksToReexecute) {
+        LOG.info("KAFKA-19148 DEBUG: Task {} for partition {} stuck in re-execution. " +
+                 "Old replicas: {}, New replicas: {}, Old leader: {}, State: {}",
+                 task.executionId(), task.proposal().topicPartition(),
+                 task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                 task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                 task.proposal().oldLeader().brokerId(), task.state());
+      }
     }
 
     return tasksToReexecute;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -441,8 +441,11 @@ public final class ExecutionUtils {
   }
 
   /**
-   * Filter out tasks that might cause KAFKA-19148 unclean leader elections.
-   * This method validates tasks against the current cluster state before execution.
+   * Filters out KAFKA-19148 unsafe tasks from the given list of tasks.
+   *
+   * @param adminClient The admin client to use for fetching cluster metadata.
+   * @param tasks The list of tasks to filter.
+   * @return The list of safe tasks that can be executed.
    */
   private static List<ExecutionTask> filterKafka19148UnsafeTasks(AdminClient adminClient,
                                                                   List<ExecutionTask> tasks) {
@@ -498,8 +501,8 @@ public final class ExecutionUtils {
 
         // Check if this task is already complete but stuck due to replica ordering
         if (isTaskEffectivelyComplete(task, partitionInfo)) {
-          LOG.warn("KAFKA-19148 REPLICA-ORDER-MISMATCH: Task {} for partition {} appears complete but stuck due to replica ordering. " +
-                   "Expected order: {}, Actual order: {}. Skipping to prevent stuck execution.",
+          LOG.warn("KAFKA-19148 REPLICA-ORDER-MISMATCH: Task {} for partition {} appears complete but stuck due to replica ordering. "
+                   + "Expected order: {}, Actual order: {}. Skipping to prevent stuck execution.",
                    task.executionId(), tp,
                    task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
                    partitionInfo.replicas().stream().map(Node::id).collect(Collectors.toList()));
@@ -517,7 +520,8 @@ public final class ExecutionUtils {
             .map(ReplicaPlacementInfo::brokerId)
             .collect(Collectors.toSet());
 
-        LOG.debug("KAFKA-19148 check: Validating task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
+        LOG.debug("KAFKA-19148 check: Validating task {} for partition {}: current leader={}, current ISR={}, "
+                  + "proposed replicas={}",
                   task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
 
         // Check if removing current leader
@@ -533,8 +537,8 @@ public final class ExecutionUtils {
                 .filter(id -> !currentIsrIds.contains(id))
                 .collect(Collectors.toSet());
 
-            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - removing current leader {} " +
-                     "while proposed replicas {} are not in ISR. Current ISR: {}. This could lead to unclean leader election.",
+            LOG.warn("KAFKA-19148 EXECUTION-TIME BLOCKED: Skipping task {} for partition {} - removing current leader {} "
+                     + "while proposed replicas {} are not in ISR. Current ISR: {}. This could lead to unclean leader election.",
                      task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds);
             // Skip this unsafe task
             continue;
@@ -552,10 +556,15 @@ public final class ExecutionUtils {
                   task.executionId(), tp);
       }
 
+    } catch (RuntimeException e) {
+      // Re-throw runtime exceptions as they may indicate other errors;
+      // https://spotbugs.readthedocs.io/en/latest/detectors.html#runtimeexceptioncapture
+      throw e;
     } catch (Exception e) {
-      LOG.error("KAFKA-19148 check: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. " +
-                "Tasks: {}, Error: {}", tasks.size(),
-                tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(), t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
+      LOG.error("KAFKA-19148 check: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. "
+                + "Tasks: {}, Error: {}", tasks.size(),
+                tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(),
+                    t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
                 e.getMessage(), e);
       // In case of error, be conservative and block all tasks to prevent KAFKA-19148
       return Collections.emptyList();
@@ -570,6 +579,10 @@ public final class ExecutionUtils {
   /**
    * Checks if a task is effectively complete despite replica ordering differences.
    * This handles cases where the replica set matches but the order doesn't.
+   *
+   * @param task The task to check.
+   * @param partitionInfo The current partition information.
+   * @return true if the task is effectively complete, false otherwise.
    */
   private static boolean isTaskEffectivelyComplete(ExecutionTask task, TopicPartitionInfo partitionInfo) {
     // Get the proposed and current replica sets (ignoring order)
@@ -621,18 +634,23 @@ public final class ExecutionUtils {
 
     List<ExecutionTask> safeTasks = filterKafka19148UnsafeTasks(adminClient, tasks);
     if (safeTasks.isEmpty()) {
-      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}. " +
-               "Returning empty result - no tasks will be executed.",
-                tasks.size(), tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. Original tasks: {}. "
+               + "Returning empty result - no tasks will be executed.",
+                tasks.size(), tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
+                    t.proposal().topicPartition())).collect(Collectors.toList()));
       // Return an empty result instead of throwing exception - this allows execution to complete gracefully
       return adminClient.alterPartitionReassignments(Collections.emptyMap());
     }
 
     if (safeTasks.size() < tasks.size()) {
-      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, Filtered tasks: {}",
+      LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, "
+               + "Filtered tasks: {}",
                tasks.size() - safeTasks.size(), tasks.size(),
-               safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
-               tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+               safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
+                   t.proposal().topicPartition())).collect(Collectors.toList()),
+               tasks.stream().filter(t -> !safeTasks.contains(t))
+                   .map(t -> String.format("Task-%d:%s", t.executionId(),
+                       t.proposal().topicPartition())).collect(Collectors.toList()));
     } else {
       LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());
     }
@@ -727,8 +745,8 @@ public final class ExecutionUtils {
       LOG.info("Found tasks to re-execute: {} while detected in-movement partitions: {}.", tasksToReexecute, partitionsInMovement);
       // Add detailed logging for KAFKA-19148 debugging
       for (ExecutionTask task : tasksToReexecute) {
-        LOG.debug("KAFKA-19148 DEBUG: Task {} for partition {} stuck in re-execution. " +
-                  "Old replicas: {}, New replicas: {}, Old leader: {}, State: {}",
+        LOG.debug("KAFKA-19148 DEBUG: Task {} for partition {} stuck in re-execution. "
+                  + "Old replicas: {}, New replicas: {}, Old leader: {}, State: {}",
                   task.executionId(), task.proposal().topicPartition(),
                   task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
                   task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -458,14 +458,14 @@ public final class ExecutionUtils {
           .map(task -> task.proposal().topicPartition().topic())
           .collect(Collectors.toSet());
 
-      LOG.info("KAFKA-19148 check: Fetching current metadata for {} topics: {}",
-               topicsToCheck.size(), topicsToCheck);
+      LOG.debug("KAFKA-19148 check: Fetching current metadata for {} topics: {}",
+                topicsToCheck.size(), topicsToCheck);
 
       DescribeTopicsResult describeResult = adminClient.describeTopics(topicsToCheck);
       Map<String, TopicDescription> topicDescriptions = describeResult.all().get(30, TimeUnit.SECONDS);
 
-      LOG.info("KAFKA-19148 check: Successfully retrieved metadata for {} topics",
-               topicDescriptions.size());
+      LOG.debug("KAFKA-19148 check: Successfully retrieved metadata for {} topics",
+                topicDescriptions.size());
 
       for (ExecutionTask task : tasks) {
         TopicPartition tp = task.proposal().topicPartition();
@@ -517,8 +517,8 @@ public final class ExecutionUtils {
             .map(ReplicaPlacementInfo::brokerId)
             .collect(Collectors.toSet());
 
-        LOG.info("KAFKA-19148 check: Validating task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
-                 task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
+        LOG.debug("KAFKA-19148 check: Validating task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
+                  task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
 
         // Check if removing current leader
         boolean removingCurrentLeader = !proposedReplicaIds.contains(currentLeader.id());
@@ -540,16 +540,16 @@ public final class ExecutionUtils {
             continue;
           }
 
-          LOG.info("KAFKA-19148 check: Task {} is safe - all proposed replicas are in ISR when removing leader",
-                   task.executionId());
+          LOG.debug("KAFKA-19148 check: Task {} is safe - all proposed replicas are in ISR when removing leader",
+                    task.executionId());
         } else {
-          LOG.info("KAFKA-19148 check: Task {} is safe - leader {} remains in proposed replica set",
-                   task.executionId(), currentLeader.id());
+          LOG.debug("KAFKA-19148 check: Task {} is safe - leader {} remains in proposed replica set",
+                    task.executionId(), currentLeader.id());
         }
 
         safeTasks.add(task);
-        LOG.info("KAFKA-19148 execution-time check: Task {} for partition {} is SAFE to execute",
-                 task.executionId(), tp);
+        LOG.debug("KAFKA-19148 execution-time check: Task {} for partition {} is SAFE to execute",
+                  task.executionId(), tp);
       }
 
     } catch (Exception e) {
@@ -561,8 +561,8 @@ public final class ExecutionUtils {
       return Collections.emptyList();
     }
 
-    LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation",
-             safeTasks.size(), tasks.size());
+    LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: {} of {} tasks passed safety validation",
+              safeTasks.size(), tasks.size());
 
     return safeTasks;
   }
@@ -611,12 +611,12 @@ public final class ExecutionUtils {
     }
 
     // KAFKA-19148 protection: Filter out potentially unsafe tasks
-    LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: Validating {} tasks for safety before submission", tasks.size());
+    LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: Validating {} tasks for safety before submission", tasks.size());
     for (ExecutionTask task : tasks) {
-      LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: Validating task {} for partition {} (state: {}, proposal: {} -> {})",
-               task.executionId(), task.proposal().topicPartition(), task.state(),
-               task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
-               task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
+      LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: Validating task {} for partition {} (state: {}, proposal: {} -> {})",
+                task.executionId(), task.proposal().topicPartition(), task.state(),
+                task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
     }
 
     List<ExecutionTask> safeTasks = filterKafka19148UnsafeTasks(adminClient, tasks);
@@ -632,7 +632,7 @@ public final class ExecutionUtils {
                safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
                tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
     } else {
-      LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());
+      LOG.debug("KAFKA-19148 EXECUTION-TIME CHECK: All {} tasks passed safety validation", tasks.size());
     }
 
     // Update the ongoing replica reassignments in case the task status has changed.
@@ -660,8 +660,8 @@ public final class ExecutionUtils {
           // Likewise, no need to check if there is already an ongoing execution for the partition, because if one
           // exists, it will be modified to execute the desired task.
           newReassignments.put(tp, reassignmentValue(newReplicas));
-          LOG.info("Submitting IN_PROGRESS task {} for execution: partition={}, newReplicas={}",
-                   task.executionId(), tp, newReplicas);
+          LOG.debug("Submitting IN_PROGRESS task {} for execution: partition={}, newReplicas={}",
+                    task.executionId(), tp, newReplicas);
           LOG.debug("Task {} will be executed.", task);
           break;
         default:
@@ -725,12 +725,12 @@ public final class ExecutionUtils {
       LOG.info("Found tasks to re-execute: {} while detected in-movement partitions: {}.", tasksToReexecute, partitionsInMovement);
       // Add detailed logging for KAFKA-19148 debugging
       for (ExecutionTask task : tasksToReexecute) {
-        LOG.info("KAFKA-19148 DEBUG: Task {} for partition {} stuck in re-execution. " +
-                 "Old replicas: {}, New replicas: {}, Old leader: {}, State: {}",
-                 task.executionId(), task.proposal().topicPartition(),
-                 task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
-                 task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
-                 task.proposal().oldLeader().brokerId(), task.state());
+        LOG.debug("KAFKA-19148 DEBUG: Task {} for partition {} stuck in re-execution. " +
+                  "Old replicas: {}, New replicas: {}, Old leader: {}, State: {}",
+                  task.executionId(), task.proposal().topicPartition(),
+                  task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                  task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                  task.proposal().oldLeader().brokerId(), task.state());
       }
     }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -642,7 +642,7 @@ public final class ExecutionUtils {
    */
   public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient,
                                                                                  List<ExecutionTask> tasks) {
-    return submitReplicaReassignmentTasks(adminClient, tasks, null);
+    return submitReplicaReassignmentTasks(adminClient, tasks, null, null);
   }
 
   /**
@@ -654,11 +654,13 @@ public final class ExecutionUtils {
    * @param adminClient The adminClient to submit new inter-broker replica reassignments.
    * @param tasks Inter-broker replica reassignment tasks to execute.
    * @param tasksToMarkComplete Optional list to populate with tasks that should be marked as complete.
+   * @param tasksToMarkDead Optional list to populate with tasks that should be marked as dead (unsafe).
    * @return The {@link AlterPartitionReassignmentsResult result} of reassignment request -- cannot be {@code null}.
    */
   public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient,
                                                                                  List<ExecutionTask> tasks,
-                                                                                 List<ExecutionTask> tasksToMarkComplete) {
+                                                                                 List<ExecutionTask> tasksToMarkComplete,
+                                                                                 List<ExecutionTask> tasksToMarkDead) {
     if (validateNotNull(tasks, "Tasks to execute cannot be null.").isEmpty()) {
       throw new IllegalArgumentException("Tasks to execute cannot be empty.");
     }
@@ -689,9 +691,25 @@ public final class ExecutionUtils {
                    t.proposal().topicPartition())).collect(Collectors.toList()));
     }
     
+    // Identify unsafe tasks that should be marked as DEAD
+    if (safeTasks.size() < tasks.size() || !completedTasks.isEmpty()) {
+      Set<ExecutionTask> unsafeTasks = new HashSet<>(tasks);
+      unsafeTasks.removeAll(safeTasks);
+      unsafeTasks.removeAll(completedTasks); // Don't mark completed ones as DEAD
+      
+      if (!unsafeTasks.isEmpty() && tasksToMarkDead != null) {
+        tasksToMarkDead.addAll(unsafeTasks);
+        LOG.info("KAFKA-19148 EXECUTION-TIME CHECK: {} tasks are unsafe (would cause unclean leader election). "
+                 + "These will be marked as DEAD: {}",
+                 unsafeTasks.size(),
+                 unsafeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),
+                     t.proposal().topicPartition())).collect(Collectors.toList()));
+      }
+    }
+    
     if (safeTasks.isEmpty()) {
       LOG.warn("KAFKA-19148 EXECUTION-TIME CHECK: ALL {} tasks were filtered out by safety check. "
-               + "{} marked as complete, {} blocked. Original tasks: {}. "
+               + "{} marked as complete, {} marked as dead. Original tasks: {}. "
                + "Returning empty result - no new tasks will be executed.",
                 tasks.size(), completedTasks.size(), tasks.size() - completedTasks.size(),
                 tasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1641,7 +1641,8 @@ public class Executor {
           LOG.debug("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. "
                    + "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
           List<ExecutionTask> tasksToMarkComplete = new ArrayList<>();
-          result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute, tasksToMarkComplete);
+          List<ExecutionTask> tasksToMarkDead = new ArrayList<>();
+          result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute, tasksToMarkComplete, tasksToMarkDead);
 
           // Mark any tasks that are already complete (replica ordering mismatch)
           if (!tasksToMarkComplete.isEmpty()) {
@@ -1650,6 +1651,17 @@ public class Executor {
             for (ExecutionTask task : tasksToMarkComplete) {
               _executionTaskManager.markTaskDone(task);
               LOG.debug("KAFKA-19148: Marked task {} for partition {} as complete",
+                        task.executionId(), task.proposal().topicPartition());
+            }
+          }
+          
+          // Mark any unsafe tasks as DEAD to prevent stuck rebalances
+          if (!tasksToMarkDead.isEmpty()) {
+            LOG.info("KAFKA-19148: Marking {} unsafe tasks as DEAD to prevent unclean leader election",
+                     tasksToMarkDead.size());
+            for (ExecutionTask task : tasksToMarkDead) {
+              _executionTaskManager.markTaskDead(task);
+              LOG.debug("KAFKA-19148: Marked task {} for partition {} as DEAD (would cause unclean leader election)",
                         task.executionId(), task.proposal().topicPartition());
             }
           }
@@ -2242,7 +2254,8 @@ public class Executor {
         }
 
         List<ExecutionTask> tasksToMarkComplete = new ArrayList<>();
-        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution, tasksToMarkComplete);
+        // Note: We don't need tasksToMarkDead here because unsafe tasks are already marked as DEAD above
+        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution, tasksToMarkComplete, null);
         
         // Mark any tasks that are already complete (replica ordering mismatch)
         if (!tasksToMarkComplete.isEmpty()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -25,8 +25,10 @@ import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,6 +52,7 @@ import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.clients.admin.PartitionReassignment;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -1611,6 +1614,8 @@ public class Executor {
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
       long startTime = System.currentTimeMillis();
+      LOG.info("KAFKA-19148 EXECUTION: Starting {} inter-broker partition movements. Total data to move: {} MB", 
+               numTotalPartitionMovements, totalDataToMoveInMB);
       LOG.info("User task {}: Starting {} inter-broker partition movements.", _uuid, numTotalPartitionMovements);
 
       int partitionsToMove = numTotalPartitionMovements;
@@ -1618,13 +1623,24 @@ public class Executor {
       while ((partitionsToMove > 0 || !inExecutionTasks().isEmpty()) && _stopSignal.get() == NO_STOP_EXECUTION) {
         // Get tasks to execute.
         List<ExecutionTask> tasksToExecute = _executionTaskManager.getInterBrokerReplicaMovementTasks();
+        LOG.info("KAFKA-19148 EXECUTION: Retrieved {} inter-broker replica movement tasks for execution. " +
+                 "Tasks will be validated at execution time by filterKafka19148UnsafeTasks.", tasksToExecute.size());
         LOG.info("User task {}: Executor will execute {} task(s)", _uuid, tasksToExecute.size());
 
         AlterPartitionReassignmentsResult result = null;
         if (!tasksToExecute.isEmpty()) {
           throttleHelper.setThrottles(tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
           // Execute the tasks.
+          LOG.info("KAFKA-19148 EXECUTION: Marking {} tasks as IN_PROGRESS before submission", tasksToExecute.size());
+          for (ExecutionTask task : tasksToExecute) {
+            LOG.debug("KAFKA-19148 EXECUTION: Task {} for partition {} (replicas {} -> {}) being marked IN_PROGRESS",
+                      task.executionId(), task.proposal().topicPartition(),
+                      task.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                      task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
+          }
           _executionTaskManager.markTasksInProgress(tasksToExecute);
+          LOG.info("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. " +
+                   "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
           result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
         }
         // Wait indefinitely for partition movements to finish.
@@ -1741,6 +1757,8 @@ public class Executor {
      */
     private void moveLeaderships() {
       int numTotalLeadershipMovements = _executionTaskManager.numRemainingLeadershipMovements();
+      LOG.info("KAFKA-19148 EXECUTION: Starting {} pure leadership movements (LEADER_ACTION tasks). " +
+               "These tasks do not change replica sets and cannot trigger KAFKA-19148.", numTotalLeadershipMovements);
       LOG.info("User task {}: Starting {} leadership movements.", _uuid, numTotalLeadershipMovements);
       int numFinishedLeadershipMovements = 0;
       while (_executionTaskManager.numRemainingLeadershipMovements() != 0 && _stopSignal.get() == NO_STOP_EXECUTION) {
@@ -2180,7 +2198,26 @@ public class Executor {
         tasksToReexecute = Collections.emptyList();
       }
       if (!tasksToReexecute.isEmpty()) {
-        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToReexecute);
+        LOG.warn("KAFKA-19148 BYPASS RISK: Re-executing {} inter-broker tasks via REEXECUTION path. Applying KAFKA-19148 validation. " +
+                 "Tasks: {}", tasksToReexecute.size(),
+                 tasksToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:%s->%s)", 
+                     t.executionId(), t.proposal().topicPartition(), t.state(),
+                     t.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                     t.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()))).collect(Collectors.toList()));
+        
+        // KAFKA-19148 CRITICAL FIX: Re-validate tasks against current cluster state before re-execution
+        List<ExecutionTask> safeTasksForReexecution = validateTasksForKafka19148(tasksToReexecute);
+        if (safeTasksForReexecution.isEmpty()) {
+          LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check", tasksToReexecute.size());
+          return;
+        }
+        
+        if (safeTasksForReexecution.size() < tasksToReexecute.size()) {
+          LOG.warn("KAFKA-19148 SAFETY: Filtered out {} unsafe re-execution tasks out of {} total", 
+                   tasksToReexecute.size() - safeTasksForReexecution.size(), tasksToReexecute.size());
+        }
+        
+        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution);
         // Process the partition reassignment result.
         Set<TopicPartition> noReassignmentToCancel = new HashSet<>();
         ExecutionUtils.processAlterPartitionReassignmentsResult(result, deleted, dead, noReassignmentToCancel);
@@ -2221,6 +2258,12 @@ public class Executor {
     private void maybeReexecuteLeadershipTasks(Set<TopicPartition> deleted) {
       List<ExecutionTask> leaderActionsToReexecute = new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(LEADER_ACTION)));
       if (!leaderActionsToReexecute.isEmpty()) {
+        LOG.info("KAFKA-19148 SAFE: Re-executing {} pure leadership tasks via REEXECUTION path. " +
+                 "Pure leader movements do not change replica sets and cannot trigger unclean elections. " +
+                 "Tasks: {}", leaderActionsToReexecute.size(),
+                 leaderActionsToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:leader %s->%s)", 
+                     t.executionId(), t.proposal().topicPartition(), t.state(),
+                     t.proposal().oldLeader().brokerId(), t.proposal().newLeader().brokerId())).collect(Collectors.toList()));
         LOG.info("User task {}: Reexecuting tasks {}", _uuid, leaderActionsToReexecute);
         ElectLeadersResult electLeadersResult = ExecutionUtils.submitPreferredLeaderElection(_adminClient, leaderActionsToReexecute);
         ExecutionUtils.processElectLeadersResult(electLeadersResult, deleted);
@@ -2232,6 +2275,109 @@ public class Executor {
         _partitionMovementMbPerSec.set(totalDataToMoveInMB / (double) executionTimeMs * 1000);
         _partitionMovementCountPerSec.set(numTotalPartitionMovements / (double) executionTimeMs * 1000);
       }
+    }
+
+    /**
+     * Validates inter-broker replica movement tasks against KAFKA-19148 to prevent unclean leader elections.
+     * This method re-validates tasks that may have been created with stale metadata.
+     * 
+     * @param tasks The tasks to validate
+     * @return List of tasks that are safe to execute
+     */
+    private List<ExecutionTask> validateTasksForKafka19148(List<ExecutionTask> tasks) {
+      if (tasks.isEmpty()) {
+        return tasks;
+      }
+      
+      LOG.info("KAFKA-19148 RE-VALIDATION: Validating {} tasks against current cluster state", tasks.size());
+      
+      List<ExecutionTask> safeTasks = new ArrayList<>();
+      try {
+        // Get fresh cluster metadata
+        Cluster cluster = getClusterForExecutionProgressCheck();
+        
+        for (ExecutionTask task : tasks) {
+          TopicPartition tp = task.proposal().topicPartition();
+          PartitionInfo partitionInfo = cluster.partition(tp);
+          
+          if (partitionInfo == null) {
+            LOG.warn("KAFKA-19148 RE-VALIDATION: Partition {} not found in cluster, skipping task {}", 
+                     tp, task.executionId());
+            continue;
+          }
+          
+          // Get current leader and ISR
+          Node currentLeader = partitionInfo.leader();
+          if (currentLeader == null) {
+            LOG.info("KAFKA-19148 RE-VALIDATION: Partition {} has no leader, allowing task {} to proceed", 
+                     tp, task.executionId());
+            safeTasks.add(task);
+            continue;
+          }
+          
+          Set<Integer> currentIsrIds = Arrays.stream(partitionInfo.inSyncReplicas())
+              .map(Node::id)
+              .collect(Collectors.toSet());
+          
+          Set<Integer> proposedReplicaIds = task.proposal().newReplicas().stream()
+              .map(ReplicaPlacementInfo::brokerId)
+              .collect(Collectors.toSet());
+          
+          LOG.info("KAFKA-19148 RE-VALIDATION: Task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
+                   task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
+          
+          // Check if removing current leader
+          if (!proposedReplicaIds.contains(currentLeader.id())) {
+            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} would remove current leader {} from partition {}",
+                     task.executionId(), currentLeader.id(), tp);
+            
+            // Current leader being removed - check if ALL proposed replicas are in ISR
+            boolean allProposedReplicasInIsr = proposedReplicaIds.stream()
+                .allMatch(currentIsrIds::contains);
+            
+            if (!allProposedReplicasInIsr) {
+              Set<Integer> nonIsrReplicas = proposedReplicaIds.stream()
+                  .filter(id -> !currentIsrIds.contains(id))
+                  .collect(Collectors.toSet());
+              
+              LOG.warn("KAFKA-19148 RE-VALIDATION BLOCKED: Skipping task {} for partition {} - " +
+                       "removing current leader {} while non-ISR replicas {} would remain in replica set. " +
+                       "Current ISR: {}, proposed replicas: {}", 
+                       task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds, proposedReplicaIds);
+              continue; // Skip this unsafe task
+            }
+            
+            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
+                     task.executionId(), currentLeader.id(), proposedReplicaIds);
+          } else {
+            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} is safe - leader {} remains in proposed replica set",
+                     task.executionId(), currentLeader.id());
+          }
+          
+          LOG.info("KAFKA-19148 RE-VALIDATION: Task {} for partition {} is SAFE to re-execute", 
+                   task.executionId(), tp);
+          safeTasks.add(task);
+        }
+        
+        if (safeTasks.size() < tasks.size()) {
+          LOG.warn("KAFKA-19148 RE-VALIDATION: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, Filtered tasks: {}",
+                   tasks.size() - safeTasks.size(), tasks.size(),
+                   safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
+                   tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+        } else {
+          LOG.info("KAFKA-19148 RE-VALIDATION: All {} tasks passed safety validation", tasks.size());
+        }
+        
+      } catch (Exception e) {
+        LOG.error("KAFKA-19148 RE-VALIDATION: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. " +
+                  "Tasks: {}, Error: {}", tasks.size(),
+                  tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(), t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
+                  e.getMessage(), e);
+        // In case of error, be conservative and block all tasks to prevent KAFKA-19148
+        return Collections.emptyList();
+      }
+      
+      return safeTasks;
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -2206,14 +2206,27 @@ public class Executor {
 
         // KAFKA-19148 CRITICAL FIX: Re-validate tasks against current cluster state before re-execution
         List<ExecutionTask> safeTasksForReexecution = validateTasksForKafka19148(tasksToReexecute);
-        if (safeTasksForReexecution.isEmpty()) {
-          LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check", tasksToReexecute.size());
-          return;
-        }
-
+        
+        // Mark unsafe tasks as DEAD to prevent infinite re-execution loops
         if (safeTasksForReexecution.size() < tasksToReexecute.size()) {
-          LOG.warn("KAFKA-19148 SAFETY: Filtered out {} unsafe re-execution tasks out of {} total",
-                   tasksToReexecute.size() - safeTasksForReexecution.size(), tasksToReexecute.size());
+          Set<ExecutionTask> unsafeTasks = new HashSet<>(tasksToReexecute);
+          unsafeTasks.removeAll(safeTasksForReexecution);
+          for (ExecutionTask unsafeTask : unsafeTasks) {
+            LOG.warn("KAFKA-19148 SAFETY: Marking task {} as DEAD to prevent re-execution loop. "
+                     + "Partition: {}, Move: {} -> {}",
+                     unsafeTask.executionId(), unsafeTask.proposal().topicPartition(),
+                     unsafeTask.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
+                     unsafeTask.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
+            _executionTaskManager.markTaskDead(unsafeTask);
+          }
+          LOG.warn("KAFKA-19148 SAFETY: Marked {} unsafe tasks as DEAD out of {} total re-execution tasks",
+                   unsafeTasks.size(), tasksToReexecute.size());
+        }
+        
+        if (safeTasksForReexecution.isEmpty()) {
+          LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check and marked as DEAD", 
+                   tasksToReexecute.size());
+          return;
         }
 
         AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -2255,7 +2255,10 @@ public class Executor {
 
         List<ExecutionTask> tasksToMarkComplete = new ArrayList<>();
         // Note: We don't need tasksToMarkDead here because unsafe tasks are already marked as DEAD above
-        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution, tasksToMarkComplete, null);
+        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, 
+                                                                                                  safeTasksForReexecution, 
+                                                                                                  tasksToMarkComplete, 
+                                                                                                  null);
         
         // Mark any tasks that are already complete (replica ordering mismatch)
         if (!tasksToMarkComplete.isEmpty()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -61,7 +61,6 @@ import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collection;
-import java.util.List;
 
 import static com.linkedin.cruisecontrol.CruiseControlUtils.currentUtcDate;
 import static com.linkedin.cruisecontrol.CruiseControlUtils.utcDateFor;
@@ -1614,7 +1613,7 @@ public class Executor {
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
       long startTime = System.currentTimeMillis();
-      LOG.debug("KAFKA-19148 EXECUTION: Starting {} inter-broker partition movements. Total data to move: {} MB", 
+      LOG.debug("KAFKA-19148 EXECUTION: Starting {} inter-broker partition movements. Total data to move: {} MB",
                numTotalPartitionMovements, totalDataToMoveInMB);
       LOG.info("User task {}: Starting {} inter-broker partition movements.", _uuid, numTotalPartitionMovements);
 
@@ -1623,8 +1622,8 @@ public class Executor {
       while ((partitionsToMove > 0 || !inExecutionTasks().isEmpty()) && _stopSignal.get() == NO_STOP_EXECUTION) {
         // Get tasks to execute.
         List<ExecutionTask> tasksToExecute = _executionTaskManager.getInterBrokerReplicaMovementTasks();
-        LOG.debug("KAFKA-19148 EXECUTION: Retrieved {} inter-broker replica movement tasks for execution. " +
-                 "Tasks will be validated at execution time by filterKafka19148UnsafeTasks.", tasksToExecute.size());
+        LOG.debug("KAFKA-19148 EXECUTION: Retrieved {} inter-broker replica movement tasks for execution. "
+                 + "Tasks will be validated at execution time by filterKafka19148UnsafeTasks.", tasksToExecute.size());
         LOG.info("User task {}: Executor will execute {} task(s)", _uuid, tasksToExecute.size());
 
         AlterPartitionReassignmentsResult result = null;
@@ -1639,8 +1638,8 @@ public class Executor {
                       task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
           }
           _executionTaskManager.markTasksInProgress(tasksToExecute);
-          LOG.debug("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. " +
-                   "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
+          LOG.debug("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. "
+                   + "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
           result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
         }
         // Wait indefinitely for partition movements to finish.
@@ -1757,8 +1756,8 @@ public class Executor {
      */
     private void moveLeaderships() {
       int numTotalLeadershipMovements = _executionTaskManager.numRemainingLeadershipMovements();
-      LOG.debug("KAFKA-19148 EXECUTION: Starting {} pure leadership movements (LEADER_ACTION tasks). " +
-               "These tasks do not change replica sets and cannot trigger KAFKA-19148.", numTotalLeadershipMovements);
+      LOG.debug("KAFKA-19148 EXECUTION: Starting {} pure leadership movements (LEADER_ACTION tasks). "
+               + "These tasks do not change replica sets and cannot trigger KAFKA-19148.", numTotalLeadershipMovements);
       LOG.info("User task {}: Starting {} leadership movements.", _uuid, numTotalLeadershipMovements);
       int numFinishedLeadershipMovements = 0;
       while (_executionTaskManager.numRemainingLeadershipMovements() != 0 && _stopSignal.get() == NO_STOP_EXECUTION) {
@@ -2198,25 +2197,25 @@ public class Executor {
         tasksToReexecute = Collections.emptyList();
       }
       if (!tasksToReexecute.isEmpty()) {
-        LOG.warn("KAFKA-19148 BYPASS RISK: Re-executing {} inter-broker tasks via REEXECUTION path. Applying KAFKA-19148 validation. " +
-                 "Tasks: {}", tasksToReexecute.size(),
-                 tasksToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:%s->%s)", 
+        LOG.warn("KAFKA-19148 BYPASS RISK: Re-executing {} inter-broker tasks via REEXECUTION path. Applying KAFKA-19148 validation. "
+                 + "Tasks: {}", tasksToReexecute.size(),
+                 tasksToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:%s->%s)",
                      t.executionId(), t.proposal().topicPartition(), t.state(),
                      t.proposal().oldReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()),
                      t.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()))).collect(Collectors.toList()));
-        
+
         // KAFKA-19148 CRITICAL FIX: Re-validate tasks against current cluster state before re-execution
         List<ExecutionTask> safeTasksForReexecution = validateTasksForKafka19148(tasksToReexecute);
         if (safeTasksForReexecution.isEmpty()) {
           LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check", tasksToReexecute.size());
           return;
         }
-        
+
         if (safeTasksForReexecution.size() < tasksToReexecute.size()) {
-          LOG.warn("KAFKA-19148 SAFETY: Filtered out {} unsafe re-execution tasks out of {} total", 
+          LOG.warn("KAFKA-19148 SAFETY: Filtered out {} unsafe re-execution tasks out of {} total",
                    tasksToReexecute.size() - safeTasksForReexecution.size(), tasksToReexecute.size());
         }
-        
+
         AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution);
         // Process the partition reassignment result.
         Set<TopicPartition> noReassignmentToCancel = new HashSet<>();
@@ -2258,10 +2257,10 @@ public class Executor {
     private void maybeReexecuteLeadershipTasks(Set<TopicPartition> deleted) {
       List<ExecutionTask> leaderActionsToReexecute = new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(LEADER_ACTION)));
       if (!leaderActionsToReexecute.isEmpty()) {
-        LOG.debug("KAFKA-19148 SAFE: Re-executing {} pure leadership tasks via REEXECUTION path. " +
-                 "Pure leader movements do not change replica sets and cannot trigger unclean elections. " +
-                 "Tasks: {}", leaderActionsToReexecute.size(),
-                 leaderActionsToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:leader %s->%s)", 
+        LOG.debug("KAFKA-19148 SAFE: Re-executing {} pure leadership tasks via REEXECUTION path. "
+                 + "Pure leader movements do not change replica sets and cannot trigger unclean elections. "
+                 + "Tasks: {}", leaderActionsToReexecute.size(),
+                 leaderActionsToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:leader %s->%s)",
                      t.executionId(), t.proposal().topicPartition(), t.state(),
                      t.proposal().oldLeader().brokerId(), t.proposal().newLeader().brokerId())).collect(Collectors.toList()));
         LOG.info("User task {}: Reexecuting tasks {}", _uuid, leaderActionsToReexecute);
@@ -2280,7 +2279,7 @@ public class Executor {
     /**
      * Validates inter-broker replica movement tasks against KAFKA-19148 to prevent unclean leader elections.
      * This method re-validates tasks that may have been created with stale metadata.
-     * 
+     *
      * @param tasks The tasks to validate
      * @return List of tasks that are safe to execute
      */
@@ -2288,95 +2287,100 @@ public class Executor {
       if (tasks.isEmpty()) {
         return tasks;
       }
-      
+
       LOG.debug("KAFKA-19148 RE-VALIDATION: Validating {} tasks against current cluster state", tasks.size());
-      
+
       List<ExecutionTask> safeTasks = new ArrayList<>();
       try {
         // Get fresh cluster metadata
         Cluster cluster = getClusterForExecutionProgressCheck();
-        
+
         for (ExecutionTask task : tasks) {
           TopicPartition tp = task.proposal().topicPartition();
           PartitionInfo partitionInfo = cluster.partition(tp);
-          
+
           if (partitionInfo == null) {
-            LOG.warn("KAFKA-19148 RE-VALIDATION: Partition {} not found in cluster, skipping task {}", 
+            LOG.warn("KAFKA-19148 RE-VALIDATION: Partition {} not found in cluster, skipping task {}",
                      tp, task.executionId());
             continue;
           }
-          
+
           // Get current leader and ISR
           Node currentLeader = partitionInfo.leader();
           if (currentLeader == null) {
-            LOG.debug("KAFKA-19148 RE-VALIDATION: Partition {} has no leader, allowing task {} to proceed", 
+            LOG.debug("KAFKA-19148 RE-VALIDATION: Partition {} has no leader, allowing task {} to proceed",
                      tp, task.executionId());
             safeTasks.add(task);
             continue;
           }
-          
+
           Set<Integer> currentIsrIds = Arrays.stream(partitionInfo.inSyncReplicas())
               .map(Node::id)
               .collect(Collectors.toSet());
-          
+
           Set<Integer> proposedReplicaIds = task.proposal().newReplicas().stream()
               .map(ReplicaPlacementInfo::brokerId)
               .collect(Collectors.toSet());
-          
+
           LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
                    task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
-          
+
           // Check if removing current leader
           if (!proposedReplicaIds.contains(currentLeader.id())) {
             LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} would remove current leader {} from partition {}",
                      task.executionId(), currentLeader.id(), tp);
-            
+
             // Current leader being removed - check if ALL proposed replicas are in ISR
             boolean allProposedReplicasInIsr = proposedReplicaIds.stream()
                 .allMatch(currentIsrIds::contains);
-            
+
             if (!allProposedReplicasInIsr) {
               Set<Integer> nonIsrReplicas = proposedReplicaIds.stream()
                   .filter(id -> !currentIsrIds.contains(id))
                   .collect(Collectors.toSet());
-              
-              LOG.warn("KAFKA-19148 RE-VALIDATION BLOCKED: Skipping task {} for partition {} - " +
-                       "removing current leader {} while non-ISR replicas {} would remain in replica set. " +
-                       "Current ISR: {}, proposed replicas: {}", 
+
+              LOG.warn("KAFKA-19148 RE-VALIDATION BLOCKED: Skipping task {} for partition {} - "
+                       + "removing current leader {} while non-ISR replicas {} would remain in replica set. "
+                       + "Current ISR: {}, proposed replicas: {}",
                        task.executionId(), tp, currentLeader.id(), nonIsrReplicas, currentIsrIds, proposedReplicaIds);
-              continue; // Skip this unsafe task
+              // Skip this unsafe task
+              continue;
             }
-            
+
             LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
                      task.executionId(), currentLeader.id(), proposedReplicaIds);
           } else {
             LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} is safe - leader {} remains in proposed replica set",
                      task.executionId(), currentLeader.id());
           }
-          
-          LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} for partition {} is SAFE to re-execute", 
+
+          LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} for partition {} is SAFE to re-execute",
                    task.executionId(), tp);
           safeTasks.add(task);
         }
-        
+
         if (safeTasks.size() < tasks.size()) {
-          LOG.warn("KAFKA-19148 RE-VALIDATION: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, Filtered tasks: {}",
+          LOG.warn("KAFKA-19148 RE-VALIDATION: Filtered out {} unsafe tasks out of {} total. Safe tasks: {}, "
+                   + "Filtered tasks: {}",
                    tasks.size() - safeTasks.size(), tasks.size(),
-                   safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
-                   tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
+                   safeTasks.stream().map(t -> String.format("Task-%d:%s",
+                       t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
+                   tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s",
+                       t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
         } else {
           LOG.debug("KAFKA-19148 RE-VALIDATION: All {} tasks passed safety validation", tasks.size());
         }
-        
+
       } catch (Exception e) {
-        LOG.error("KAFKA-19148 RE-VALIDATION: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. " +
-                  "Tasks: {}, Error: {}", tasks.size(),
-                  tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(), t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
+        LOG.error("KAFKA-19148 RE-VALIDATION: CRITICAL ERROR validating {} tasks, blocking ALL tasks for safety. "
+                  + "Tasks: {}, Error: {}", tasks.size(),
+                  tasks.stream().map(t -> String.format("Task-%d:%s(%s)", t.executionId(),
+                      t.proposal().topicPartition(), t.state())).collect(Collectors.toList()),
                   e.getMessage(), e);
         // In case of error, be conservative and block all tasks to prevent KAFKA-19148
         return Collections.emptyList();
       }
-      
+
       return safeTasks;
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1640,7 +1640,19 @@ public class Executor {
           _executionTaskManager.markTasksInProgress(tasksToExecute);
           LOG.debug("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. "
                    + "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
-          result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
+          List<ExecutionTask> tasksToMarkComplete = new ArrayList<>();
+          result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute, tasksToMarkComplete);
+
+          // Mark any tasks that are already complete (replica ordering mismatch)
+          if (!tasksToMarkComplete.isEmpty()) {
+            LOG.info("KAFKA-19148: Marking {} tasks as complete due to replica ordering mismatch",
+                     tasksToMarkComplete.size());
+            for (ExecutionTask task : tasksToMarkComplete) {
+              _executionTaskManager.markTaskDone(task);
+              LOG.debug("KAFKA-19148: Marked task {} for partition {} as complete",
+                        task.executionId(), task.proposal().topicPartition());
+            }
+          }
         }
         // Wait indefinitely for partition movements to finish.
         List<ExecutionTask> completedTasks = waitForInterBrokerReplicaTasksToFinish(result);
@@ -2206,7 +2218,7 @@ public class Executor {
 
         // KAFKA-19148 CRITICAL FIX: Re-validate tasks against current cluster state before re-execution
         List<ExecutionTask> safeTasksForReexecution = validateTasksForKafka19148(tasksToReexecute);
-        
+
         // Mark unsafe tasks as DEAD to prevent infinite re-execution loops
         if (safeTasksForReexecution.size() < tasksToReexecute.size()) {
           Set<ExecutionTask> unsafeTasks = new HashSet<>(tasksToReexecute);
@@ -2222,14 +2234,27 @@ public class Executor {
           LOG.warn("KAFKA-19148 SAFETY: Marked {} unsafe tasks as DEAD out of {} total re-execution tasks",
                    unsafeTasks.size(), tasksToReexecute.size());
         }
-        
+
         if (safeTasksForReexecution.isEmpty()) {
-          LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check and marked as DEAD", 
+          LOG.warn("KAFKA-19148 SAFETY: All {} re-execution tasks were blocked by safety check and marked as DEAD",
                    tasksToReexecute.size());
           return;
         }
 
-        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution);
+        List<ExecutionTask> tasksToMarkComplete = new ArrayList<>();
+        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, safeTasksForReexecution, tasksToMarkComplete);
+        
+        // Mark any tasks that are already complete (replica ordering mismatch)
+        if (!tasksToMarkComplete.isEmpty()) {
+          LOG.info("KAFKA-19148 RE-EXECUTION: Marking {} tasks as complete due to replica ordering mismatch", 
+                   tasksToMarkComplete.size());
+          for (ExecutionTask task : tasksToMarkComplete) {
+            _executionTaskManager.markTaskDone(task);
+            LOG.debug("KAFKA-19148 RE-EXECUTION: Marked task {} for partition {} as complete", 
+                     task.executionId(), task.proposal().topicPartition());
+          }
+        }
+        
         // Process the partition reassignment result.
         Set<TopicPartition> noReassignmentToCancel = new HashSet<>();
         ExecutionUtils.processAlterPartitionReassignmentsResult(result, deleted, dead, noReassignmentToCancel);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1614,7 +1614,7 @@ public class Executor {
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
       long startTime = System.currentTimeMillis();
-      LOG.info("KAFKA-19148 EXECUTION: Starting {} inter-broker partition movements. Total data to move: {} MB", 
+      LOG.debug("KAFKA-19148 EXECUTION: Starting {} inter-broker partition movements. Total data to move: {} MB", 
                numTotalPartitionMovements, totalDataToMoveInMB);
       LOG.info("User task {}: Starting {} inter-broker partition movements.", _uuid, numTotalPartitionMovements);
 
@@ -1623,7 +1623,7 @@ public class Executor {
       while ((partitionsToMove > 0 || !inExecutionTasks().isEmpty()) && _stopSignal.get() == NO_STOP_EXECUTION) {
         // Get tasks to execute.
         List<ExecutionTask> tasksToExecute = _executionTaskManager.getInterBrokerReplicaMovementTasks();
-        LOG.info("KAFKA-19148 EXECUTION: Retrieved {} inter-broker replica movement tasks for execution. " +
+        LOG.debug("KAFKA-19148 EXECUTION: Retrieved {} inter-broker replica movement tasks for execution. " +
                  "Tasks will be validated at execution time by filterKafka19148UnsafeTasks.", tasksToExecute.size());
         LOG.info("User task {}: Executor will execute {} task(s)", _uuid, tasksToExecute.size());
 
@@ -1631,7 +1631,7 @@ public class Executor {
         if (!tasksToExecute.isEmpty()) {
           throttleHelper.setThrottles(tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
           // Execute the tasks.
-          LOG.info("KAFKA-19148 EXECUTION: Marking {} tasks as IN_PROGRESS before submission", tasksToExecute.size());
+          LOG.debug("KAFKA-19148 EXECUTION: Marking {} tasks as IN_PROGRESS before submission", tasksToExecute.size());
           for (ExecutionTask task : tasksToExecute) {
             LOG.debug("KAFKA-19148 EXECUTION: Task {} for partition {} (replicas {} -> {}) being marked IN_PROGRESS",
                       task.executionId(), task.proposal().topicPartition(),
@@ -1639,7 +1639,7 @@ public class Executor {
                       task.proposal().newReplicas().stream().map(r -> r.brokerId()).collect(Collectors.toList()));
           }
           _executionTaskManager.markTasksInProgress(tasksToExecute);
-          LOG.info("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. " +
+          LOG.debug("KAFKA-19148 EXECUTION: Submitting {} tasks to ExecutionUtils.submitReplicaReassignmentTasks. " +
                    "Tasks will undergo final KAFKA-19148 safety validation.", tasksToExecute.size());
           result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
         }
@@ -1757,7 +1757,7 @@ public class Executor {
      */
     private void moveLeaderships() {
       int numTotalLeadershipMovements = _executionTaskManager.numRemainingLeadershipMovements();
-      LOG.info("KAFKA-19148 EXECUTION: Starting {} pure leadership movements (LEADER_ACTION tasks). " +
+      LOG.debug("KAFKA-19148 EXECUTION: Starting {} pure leadership movements (LEADER_ACTION tasks). " +
                "These tasks do not change replica sets and cannot trigger KAFKA-19148.", numTotalLeadershipMovements);
       LOG.info("User task {}: Starting {} leadership movements.", _uuid, numTotalLeadershipMovements);
       int numFinishedLeadershipMovements = 0;
@@ -2258,7 +2258,7 @@ public class Executor {
     private void maybeReexecuteLeadershipTasks(Set<TopicPartition> deleted) {
       List<ExecutionTask> leaderActionsToReexecute = new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(LEADER_ACTION)));
       if (!leaderActionsToReexecute.isEmpty()) {
-        LOG.info("KAFKA-19148 SAFE: Re-executing {} pure leadership tasks via REEXECUTION path. " +
+        LOG.debug("KAFKA-19148 SAFE: Re-executing {} pure leadership tasks via REEXECUTION path. " +
                  "Pure leader movements do not change replica sets and cannot trigger unclean elections. " +
                  "Tasks: {}", leaderActionsToReexecute.size(),
                  leaderActionsToReexecute.stream().map(t -> String.format("Task-%d:%s(%s:leader %s->%s)", 
@@ -2289,7 +2289,7 @@ public class Executor {
         return tasks;
       }
       
-      LOG.info("KAFKA-19148 RE-VALIDATION: Validating {} tasks against current cluster state", tasks.size());
+      LOG.debug("KAFKA-19148 RE-VALIDATION: Validating {} tasks against current cluster state", tasks.size());
       
       List<ExecutionTask> safeTasks = new ArrayList<>();
       try {
@@ -2309,7 +2309,7 @@ public class Executor {
           // Get current leader and ISR
           Node currentLeader = partitionInfo.leader();
           if (currentLeader == null) {
-            LOG.info("KAFKA-19148 RE-VALIDATION: Partition {} has no leader, allowing task {} to proceed", 
+            LOG.debug("KAFKA-19148 RE-VALIDATION: Partition {} has no leader, allowing task {} to proceed", 
                      tp, task.executionId());
             safeTasks.add(task);
             continue;
@@ -2323,12 +2323,12 @@ public class Executor {
               .map(ReplicaPlacementInfo::brokerId)
               .collect(Collectors.toSet());
           
-          LOG.info("KAFKA-19148 RE-VALIDATION: Task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
+          LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} for partition {}: current leader={}, current ISR={}, proposed replicas={}",
                    task.executionId(), tp, currentLeader.id(), currentIsrIds, proposedReplicaIds);
           
           // Check if removing current leader
           if (!proposedReplicaIds.contains(currentLeader.id())) {
-            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} would remove current leader {} from partition {}",
+            LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} would remove current leader {} from partition {}",
                      task.executionId(), currentLeader.id(), tp);
             
             // Current leader being removed - check if ALL proposed replicas are in ISR
@@ -2347,14 +2347,14 @@ public class Executor {
               continue; // Skip this unsafe task
             }
             
-            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
+            LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} is safe - removing leader {} but all proposed replicas {} are in ISR",
                      task.executionId(), currentLeader.id(), proposedReplicaIds);
           } else {
-            LOG.info("KAFKA-19148 RE-VALIDATION: Task {} is safe - leader {} remains in proposed replica set",
+            LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} is safe - leader {} remains in proposed replica set",
                      task.executionId(), currentLeader.id());
           }
           
-          LOG.info("KAFKA-19148 RE-VALIDATION: Task {} for partition {} is SAFE to re-execute", 
+          LOG.debug("KAFKA-19148 RE-VALIDATION: Task {} for partition {} is SAFE to re-execute", 
                    task.executionId(), tp);
           safeTasks.add(task);
         }
@@ -2365,7 +2365,7 @@ public class Executor {
                    safeTasks.stream().map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()),
                    tasks.stream().filter(t -> !safeTasks.contains(t)).map(t -> String.format("Task-%d:%s", t.executionId(), t.proposal().topicPartition())).collect(Collectors.toList()));
         } else {
-          LOG.info("KAFKA-19148 RE-VALIDATION: All {} tasks passed safety validation", tasks.size());
+          LOG.debug("KAFKA-19148 RE-VALIDATION: All {} tasks passed safety validation", tasks.size());
         }
         
       } catch (Exception e) {


### PR DESCRIPTION
## Summary
1. Why: In KRaft mode, removing a leader broker from a replica set while non-ISR replicas remain can trigger unclean leader elections (KAFKA-19148). This causes data loss and stuck reassignment tasks. Cruise Control lacked safety checks to prevent such dangerous reassignments during rebalancing operations.

2. What: Implemented comprehensive KAFKA-19148 safety checks in the goal optimization phase to prevent unsafe replica movements before they are proposed. Added automatic Kafka cluster metadata injection and validation logic to block moves that could trigger unclean leader elections.

## Expected Behavior
- Cruise Control should prevent replica movements that would remove the current leader while non-ISR replicas remain in the replica set
- Single-replica partitions should not be moved directly (requires adding replica first)
- All proposed replica movements should be validated against current ISR state
- Clear logging should indicate when moves are blocked for KAFKA-19148 safety

## Actual Behavior
- Cruise Control allows unsafe replica movements that can trigger unclean leader elections in KRaft mode
- Tasks get stuck in IN_PROGRESS state when broker reassignments fail
- No visibility into why certain moves are dangerous or blocked

## Steps to Reproduce
1. Run Kafka cluster in KRaft mode with Cruise Control
2. Create a partition with replicas on brokers where at least one replica is out of ISR
3. Trigger a rebalance that would move the current leader to a broker not in the replica set
4. Observe that without this fix, the move proceeds and can cause unclean leader election

## Known Workarounds
- Manually ensure all replicas are in ISR before triggering rebalances
- Avoid moving leader replicas when non-ISR replicas exist
- Use ZooKeeper mode instead of KRaft (not affected by KAFKA-19148)

## Additional evidence
1. Environment: Kafka in KRaft mode with Cruise Control managing cluster rebalancing
2. Logs showing stuck tasks:
<details>
<summary>Example stuck task log</summary>

```
Task 299 for partition monorail_unified_merchant_event_pageviews_1-1 stuck trying to change replicas from [8,4,6] to [8,4,9]
Current leader: broker 8, Current ISR: [4,6,8]
```
</details>

3. KAFKA-19148 blocking logs after fix:
<details>
<summary>Safety check logs</summary>

```
KAFKA-19148 BLOCKED: Cannot move single-replica partition topic-0 - would remove current leader 1 with no other replicas. Should first add replica to destination broker 2
KAFKA-19148 BLOCKED: Skipping movement for partition topic-1 - removing current leader 3 while non-ISR replicas [5] would remain in replica set. Current ISR: [3,4]
```
</details>

4. Fixed ConcurrentModificationException in LeaderReplicaDistributionGoal when iterating over broker replicas during rebalancing
5. `BrokerFailureIntegrationTest` tests are failing due to KAFKA-19148 mitigation changes. Next steps: TBD

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR addresses https://issues.apache.org/jira/browse/KAFKA-19148